### PR TITLE
Cpp pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build_bak/
 tmp/
 examples/
 example_1kg/
+*.R

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp/
 examples/
 example_1kg/
 *.R
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ examples/
 example_1kg/
 *.R
 .DS_Store
+
+# macOS
+.DS_Store
+
+# local notes/scripts
+CLAUDE.md
+submit_smoketest.sh

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -40,7 +40,8 @@ struct Args {
     std::string admixTextPrefix;  // --admix-text-prefix
     std::string keepFile;         // --keep (subject include list)
     std::string removeFile;       // --remove (subject exclude list)
-    std::string predListFile;     // --pred-list (Regenie step 1 pred.list for LOCO)
+    std::string predListFile;     // --pred-list (Regenie / LDAK-KVIK pred.list for LOCO)
+    std::string locoMode = "offset"; // --loco-mode {offset, covariate}
     bool calAfCoef = false;
     bool calPairwiseIBD = false;
     bool calPhi = false;

--- a/src/cli/dispatch.cpp
+++ b/src/cli/dispatch.cpp
@@ -181,12 +181,17 @@ static void logArgsInEffect(const Args &args) {
             args.calAfCoef || args.method == "SPAmix" || args.method == "SPAmixPlus" || args.method == "LEAF";
         if (usesPcCols && !args.pcCols.empty()) std::fprintf(stderr, "  --pc-cols %s\n", args.pcCols.c_str());
     }
-    // spasqr-taus: relevant for SPAsqr pheno path
-    if (args.method == "SPAsqr" && !args.phenoName.empty() && !args.spasqrTaus.empty())std::fprintf(
-            stderr,
-            "  --spasqr-taus %s\n",
-            args.spasqrTaus.c_str()
-    );
+    // SPAsqr-specific knobs (relevant for SPAsqr pheno path)
+    if (args.method == "SPAsqr" && !args.phenoName.empty()) {
+        if (!args.spasqrTaus.empty())
+            std::fprintf(stderr, "  --spasqr-taus %s\n", args.spasqrTaus.c_str());
+        if (args.spasqrTol != 1e-7)
+            std::fprintf(stderr, "  --spasqr-tol %g\n", args.spasqrTol);
+        if (args.spasqrH >= 0.0)
+            std::fprintf(stderr, "  --spasqr-h %g\n", args.spasqrH);
+        if (args.spasqrHScale >= 0.0)
+            std::fprintf(stderr, "  --spasqr-h-scale %g\n", args.spasqrHScale);
+    }
     // other files
     if (!args.refAfFile.empty()) std::fprintf(stderr, "  --ref-af %s\n", args.refAfFile.c_str());
     if (!args.spGrmGrabFile.empty()) std::fprintf(stderr, "  --sp-grm-grab %s\n", args.spGrmGrabFile.c_str());
@@ -196,6 +201,11 @@ static void logArgsInEffect(const Args &args) {
     if (!args.extractFile.empty()) std::fprintf(stderr, "  --extract %s\n", args.extractFile.c_str());
     if (!args.excludeFile.empty()) std::fprintf(stderr, "  --exclude %s\n", args.excludeFile.c_str());
     if (!args.chrSpec.empty()) std::fprintf(stderr, "  --chr %s\n", args.chrSpec.c_str());
+    // LOCO (SPAsqr): only meaningful when --pred-list is given
+    if (!args.predListFile.empty()) {
+        std::fprintf(stderr, "  --pred-list %s\n", args.predListFile.c_str());
+        std::fprintf(stderr, "  --loco-mode %s\n", args.locoMode.c_str());
+    }
     if (!args.admixBfilePrefix.empty()) std::fprintf(stderr, "  --admix-bfile %s\n", args.admixBfilePrefix.c_str());
     if (!args.admixPhiFile.empty()) std::fprintf(stderr, "  --admix-phi %s\n", args.admixPhiFile.c_str());
     if (!args.mspFile.empty()) std::fprintf(stderr, "  --rfmix-msp %s\n", args.mspFile.c_str());
@@ -665,7 +675,11 @@ int run(
 
         // ── SPAsqr ─────────────────────────────────────────────────
         else if (args.method == "SPAsqr") {
-            checkSpGrm(args, /*required=*/ true, "SPAsqr");
+            checkSpGrm(args, /*required=*/ false, "SPAsqr");
+            if (args.spGrmGrabFile.empty() && args.spGrmPlink2File.empty()) {
+                warnMsg("SPAsqr: no --sp-grm-grab/--sp-grm-plink2 provided;"
+                        " falling back to identity GRM (assumes unrelated subjects)");
+            }
             if (args.phenoFile.empty() && args.covarFile.empty()) {
                 std::cerr << "Error: --pheno or --covar required for SPAsqr.\n";
                 return 1;
@@ -696,6 +710,11 @@ int run(
                 taus.push_back(t);
             }
             if (!args.predListFile.empty()) {
+                if (args.locoMode != "offset" && args.locoMode != "covariate") {
+                    std::cerr << "Error: --loco-mode must be 'offset' or 'covariate', got '"
+                              << args.locoMode << "'\n";
+                    return 1;
+                }
                 // Early validation: check all phenotypes have LOCO entries
                 {
                     std::ifstream pf(args.predListFile);
@@ -748,7 +767,8 @@ int run(
                     args.spasqrH,
                     args.spasqrHScale,
                     args.keepFile,
-                    args.removeFile
+                    args.removeFile,
+                    args.locoMode
                 );
             } else {
                 runSPAsqr(

--- a/src/cli/flags.hpp
+++ b/src/cli/flags.hpp
@@ -248,9 +248,24 @@ inline const FlagDef kRemove = {
 };
 
 inline const FlagDef kPredList = {
-    "--pred-list", "FILE", "Regenie step 1 pred.list file for LOCO analysis (phenoName locoPath per line)",
+    "--pred-list", "FILE", "pred.list file for LOCO analysis (phenoName locoPath per line; Regenie or LDAK-KVIK)",
     R"(Space-separated file with two columns: phenotype name and path to
-the corresponding .loco file from Regenie step 1.)"
+the corresponding .loco file. The .loco file format is auto-detected
+per phenotype: Regenie (header begins with FID_IID, chromosome-major
+rows) or LDAK-KVIK (header FID IID Chr1 Chr2 ... Chr22, subject-major
+rows).)"
+};
+
+inline const FlagDef kLocoMode = {
+    "--loco-mode", "MODE",
+    "How LOCO PRS enters SPAsqr-LOCO: offset (default) | covariate",
+    R"(Selects how the per-chromosome LOCO PRS is consumed:
+  offset    — inverse-rank-normal-transform Y per phenotype, then fit
+              conquer on (Y_irn - loco_chr) with the original covariates
+              only (LOCO subtracted from the response as an offset).
+  covariate — append the LOCO column to the conquer covariate matrix
+              and fit conquer on (Y, [X | loco_chr]).
+Only meaningful when --pred-list is provided.)"
 };
 
 inline const FlagDef kExtract = {
@@ -478,7 +493,7 @@ inline const FlagDef *const kSPAsqrOpt[] = {
     &kPhenoName,    &kSpasqrTaus, &kSpasqrTol,  &kSpasqrH,
     &kSpasqrHScale, &kOutlierIqr, &kOutlierAbs,
     &kSpaZThresh,   &kThreads,    &kChunkSize,  &kGeno, &kMaf,
-    &kMac,          &kHwe,        &kChr,        &kPredList,
+    &kMac,          &kHwe,        &kChr,        &kPredList,    &kLocoMode,
     nullptr
 };
 

--- a/src/cli/parse.cpp
+++ b/src/cli/parse.cpp
@@ -137,6 +137,7 @@ Args parseArgs(
         else if (arg == "--keep")a.keepFile = next();
         else if (arg == "--remove")a.removeFile = next();
         else if (arg == "--pred-list")a.predListFile = next();
+        else if (arg == "--loco-mode")a.locoMode = next();
         else if (arg == "--admix-bfile")a.admixBfilePrefix = next();
         else if (arg == "--admix-phi")a.admixPhiFile = next();
         else if (arg == "--rfmix-msp")a.mspFile = next();

--- a/src/engine/loco.cpp
+++ b/src/engine/loco.cpp
@@ -33,14 +33,31 @@ using namespace engine_impl;
 // LocoData — load Regenie step 1 LOCO predictions
 // ══════════════════════════════════════════════════════════════════════
 
-// Parse a .loco file directly into aligned vectors.
+// LOCO file format. Selected by header sniff in detectLocoFormat().
+enum class LocoFormat { Regenie, Ldak };
+
+// Detect format from the first whitespace-delimited token of the header.
+//   Regenie writes the literal joined token "FID_IID".
+//   LDAK-KVIK writes two separate tokens "FID" then "IID".
+static LocoFormat detectLocoFormat(const std::string &path) {
+    std::ifstream ifs(path);
+    if (!ifs.is_open())
+        throw std::runtime_error("Cannot open LOCO file for format detection: " + path);
+    std::string firstTok;
+    ifs >> firstTok;
+    if (firstTok.empty())
+        throw std::runtime_error("Empty LOCO file: " + path);
+    return (firstTok == "FID_IID") ? LocoFormat::Regenie : LocoFormat::Ldak;
+}
+
+// Parse a Regenie .loco file directly into aligned vectors.
 // Memory-maps the file and parses with strtod for zero-copy I/O —
 // avoids ifstream/getline overhead on multi-MB lines (400K columns).
 // Only autosomal chromosomes 1–22 are kept.
 //
 // Header: FID_IID  0_HG00096  0_HG00097  ...
 // Data:   1  0.0306  0.271  ...
-static std::unordered_map<std::string, Eigen::VectorXd>parseLocoFile(
+static std::unordered_map<std::string, Eigen::VectorXd>parseRegenieLocoFile(
     const std::string &path,
     const std::vector<std::string> &usedIIDs
 ) {
@@ -186,6 +203,160 @@ static std::unordered_map<std::string, Eigen::VectorXd>parseLocoFile(
     return result;
 }
 
+// Parse an LDAK-KVIK .loco file (transpose of Regenie layout).
+// Memory-mapped, zero-copy strtod, autosomes 1–22 only.
+//
+// Header: FID  IID  Chr1  Chr2  Chr3  ...  Chr22
+// Data:   U-2  U-2  0.6455  0.4759  ...  0.8893     (one row per subject)
+//
+// Chromosome labels are normalized: "Chr1" → "1", "Chr22" → "22"
+// so downstream chunk lookups match .bim/VCF/BGEN CHROM strings.
+static std::unordered_map<std::string, Eigen::VectorXd>parseLdakLocoFile(
+    const std::string &path,
+    const std::vector<std::string> &usedIIDs
+) {
+    int fd = ::open(path.c_str(), O_RDONLY);
+    if (fd < 0) throw std::runtime_error("Cannot open LOCO file: " + path);
+
+    struct stat st;
+    if (::fstat(fd, &st) != 0) {
+        ::close(fd);
+        throw std::runtime_error("Cannot stat LOCO file: " + path);
+    }
+    const size_t fileSize = static_cast<size_t>(st.st_size);
+    if (fileSize == 0) {
+        ::close(fd);
+        throw std::runtime_error("Empty LOCO file: " + path);
+    }
+
+    void *mapped = ::mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+    ::close(fd);
+    if (mapped == MAP_FAILED)
+        throw std::runtime_error("Cannot mmap LOCO file: " + path);
+    ::madvise(mapped, fileSize, MADV_SEQUENTIAL);
+
+    struct Guard { void *p; size_t n; ~Guard()
+                   {
+                       ::munmap(p, n);
+                   }
+
+    } guard{mapped, fileSize};
+
+    const char *p = static_cast<const char *>(mapped);
+    const char *const fend = p + fileSize;
+    const auto nUsed = static_cast<Eigen::Index>(usedIIDs.size());
+
+    auto skipWS = [&]() {
+                      while (p < fend && (*p == ' ' || *p == '\t')) ++p;
+                  };
+
+    auto readToken = [&](std::string &out) {
+                         out.clear();
+                         skipWS();
+                         while (p < fend && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
+                             out.push_back(*p++);
+                     };
+
+    // ── Header: expect "FID IID Chr1 Chr2 ... Chr22" ────────────────
+    std::string tok;
+    tok.reserve(32);
+
+    readToken(tok);
+    if (tok != "FID")
+        throw std::runtime_error("LDAK LOCO " + path + ": expected first header token 'FID', got '" + tok + "'");
+    readToken(tok);
+    if (tok != "IID")
+        throw std::runtime_error("LDAK LOCO " + path + ": expected second header token 'IID', got '" + tok + "'");
+
+    // Collect chromosome columns. chrCols[c] = "1".."22" if autosomal, else empty (skip).
+    std::vector<std::string> chrCols;
+    chrCols.reserve(32);
+    while (p < fend && *p != '\n' && *p != '\r') {
+        readToken(tok);
+        if (tok.empty()) break;
+        // Strip "Chr"/"chr" prefix.
+        std::string label = tok;
+        if (label.size() > 3 && (label[0] == 'C' || label[0] == 'c') && (label[1] == 'h' || label[1] == 'H') &&
+            (label[2] == 'r' || label[2] == 'R'))
+            label = label.substr(3);
+
+        // Autosomal check: integer 1–22.
+        bool autosomal = false;
+        if (!label.empty() && label.size() <= 2) {
+            int chrNum = 0;
+            bool ok = true;
+            for (char c : label) {
+                if (c < '0' || c > '9') { ok = false; break; }
+                chrNum = chrNum * 10 + (c - '0');
+            }
+            autosomal = ok && chrNum >= 1 && chrNum <= 22;
+        }
+        chrCols.push_back(autosomal ? label : std::string{});
+    }
+    if (p < fend && *p == '\r') ++p;
+    if (p < fend && *p == '\n') ++p;
+
+    if (chrCols.empty())
+        throw std::runtime_error("LDAK LOCO " + path + ": header has no chromosome columns");
+
+    // ── Pre-allocate output vectors for each kept chromosome ─────────
+    std::unordered_map<std::string, Eigen::VectorXd> result;
+    for (const auto &c : chrCols)
+        if (!c.empty()) result[c] = Eigen::VectorXd::Zero(nUsed);
+
+    // ── Build IID → usedIIDs index ──────────────────────────────────
+    std::unordered_map<std::string, Eigen::Index> iidIdx;
+    iidIdx.reserve(usedIIDs.size());
+    for (size_t i = 0; i < usedIIDs.size(); ++i)
+        iidIdx[usedIIDs[i]] = static_cast<Eigen::Index>(i);
+
+    std::vector<bool> usedHit(usedIIDs.size(), false);
+    std::string fidTok, iidTok;
+    fidTok.reserve(64);
+    iidTok.reserve(64);
+
+    const size_t nCols = chrCols.size();
+
+    // ── Data rows: FID  IID  v1 v2 ... vN ───────────────────────────
+    while (p < fend) {
+        while (p < fend && (*p == '\n' || *p == '\r')) ++p;
+        if (p >= fend) break;
+
+        readToken(fidTok);
+        if (fidTok.empty()) break;
+        readToken(iidTok);
+        if (iidTok.empty())
+            throw std::runtime_error("LDAK LOCO " + path + ": missing IID token after FID '" + fidTok + "'");
+
+        Eigen::Index pos = -1;
+        auto it = iidIdx.find(iidTok);
+        if (it != iidIdx.end()) pos = it->second;
+
+        for (size_t c = 0; c < nCols; ++c) {
+            skipWS();
+            char *ep;
+            double val = std::strtod(p, &ep);
+            if (ep == p)
+                throw std::runtime_error("LDAK LOCO " + path + " IID '" + iidTok +
+                                         "': invalid value at column " + std::to_string(c + 1));
+            p = ep;
+            if (pos >= 0 && !chrCols[c].empty())
+                result[chrCols[c]][pos] = val;
+        }
+        if (pos >= 0) usedHit[static_cast<size_t>(pos)] = true;
+
+        while (p < fend && *p != '\n') ++p;
+        if (p < fend) ++p;
+    }
+
+    for (size_t i = 0; i < usedIIDs.size(); ++i) {
+        if (!usedHit[i])
+            throw std::runtime_error("Subject '" + usedIIDs[i] + "' not found in LDAK LOCO file: " + path);
+    }
+
+    return result;
+}
+
 LocoData LocoData::load(
     const std::string &predListFile,
     const std::vector<std::string> &phenoNames,
@@ -221,7 +392,13 @@ LocoData LocoData::load(
     for (const auto &pn : phenoNames) {
         const std::string &locoPath = predMap.at(pn);
 
-        result.scores[pn] = parseLocoFile(locoPath, usedIIDs);
+        const LocoFormat fmt = detectLocoFormat(locoPath);
+        infoMsg("LOCO[%s]: detected %s format", pn.c_str(),
+                fmt == LocoFormat::Regenie ? "regenie" : "ldak");
+
+        result.scores[pn] = (fmt == LocoFormat::Regenie)
+            ? parseRegenieLocoFile(locoPath, usedIIDs)
+            : parseLdakLocoFile(locoPath, usedIIDs);
 
         if (result.scores[pn].size() < 22)
             throw std::runtime_error("LOCO file for '" + pn + "' contains " +

--- a/src/engine/marker.cpp
+++ b/src/engine/marker.cpp
@@ -625,12 +625,14 @@ void multiPhenoEngineRange(
             std::vector<std::vector<double> > winGSums;
             std::vector<double> passAltFreqs;
             std::vector<double> passGSums;
+            std::vector<double> passGSumSqs;
             std::vector<std::vector<double> > fusedResultsBuf;
 
             if (hasFused) {
                 winGSums.resize(nFuseable, std::vector<double>(B, 0.0));
                 passAltFreqs.reserve(B);
                 passGSums.reserve(B);
+                passGSumSqs.reserve(B);
             }
 
             // Pre-allocated passScores buffer (A2): reused across windows.
@@ -784,6 +786,7 @@ void multiPhenoEngineRange(
 
                             passAltFreqs.clear();
                             passGSums.clear();
+                            passGSumSqs.clear();
                             int passCount = 0;
 
                             for (size_t bi = 0; bi < wlen; ++bi) {
@@ -814,6 +817,7 @@ void multiPhenoEngineRange(
                                 if (wmQC[bi].pass) {
                                     passAltFreqs.push_back(gs.altFreq);
                                     passGSums.push_back(gSum);
+                                    passGSumSqs.push_back(gs.sumSq);
                                     ++passCount;
                                 }
                             }
@@ -838,7 +842,7 @@ void multiPhenoEngineRange(
 
                                     methods[p]->processScoreBatch(
                                         passScoresBuf.topLeftCorner(fp.nCols, passCount),
-                                        passGSums.data(), fp.nUsed,
+                                        passGSums.data(), passGSumSqs.data(), fp.nUsed,
                                         passAltFreqs, fusedResultsBuf);
                                 }
 

--- a/src/engine/marker.hpp
+++ b/src/engine/marker.hpp
@@ -111,18 +111,20 @@ class MethodBase {
 
     // Process pre-computed raw scores (from the fused GEMM).
     //   scores   — fusedGemmColumns() × B matrix of raw scores
-    //   gSums    — per-phenotype genotype sums, length B
+    //   gSums    — per-phenotype genotype sums, length B (post-impute Σ G)
+    //   gSumSqs  — per-phenotype Σ G², length B (post-impute, for empirical variance)
     //   nUsed    — this phenotype's sample count (for gMean = gSum / nUsed)
     //   altFreqs — ALT allele frequencies, length B (pre-computed)
     //   results  — output: results[b] = method-specific result values
     virtual void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) {
-        (void)scores; (void)gSums; (void)nUsed;
+        (void)scores; (void)gSums; (void)gSumSqs; (void)nUsed;
         (void)altFreqs; (void)results;
     }
 

--- a/src/engine/marker_impl.hpp
+++ b/src/engine/marker_impl.hpp
@@ -185,6 +185,7 @@ static_assert(sizeof(PaddedFlag) == 64, "PaddedFlag must be 64 bytes");
 
 struct PhenoGenoStats {
     double altFreq, mac, missingRate, hweP;
+    double sumSq;   // post-imputation Σ G_i² over present subjects
 };
 
 // Compute per-phenotype genotype stats from union-level genotype vector
@@ -197,9 +198,11 @@ inline PhenoGenoStats statsFromUnionVec(
     uint32_t nUsed
 ) {
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0, nMissing = 0;
+    double sumSq = 0.0;
     for (uint32_t i = 0; i < nUnion; ++i) {
         if (mask[i] == 0.0) continue;  // absent from this phenotype
         const double v = unionG[i];
+        sumSq += v * v;                // post-impute Σv² (universal: hard-call/dosage/imputed)
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -210,6 +213,7 @@ inline PhenoGenoStats statsFromUnionVec(
             ++nMissing;  // NaN or dosage
     }
     PhenoGenoStats s;
+    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         // Dosage data: compute from gSum (not discrete genotypes).
@@ -238,12 +242,14 @@ inline PhenoGenoStats statsFromGVec(
 ) {
     indexForMissing.clear();
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0;
+    double sumSq = 0.0;
     for (uint32_t i = 0; i < n; ++i) {
         const double v = g[i];
         if (std::isnan(v) || v < 0.0) {
             indexForMissing.push_back(i);
             continue;
         }
+        sumSq += v * v;
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -254,6 +260,7 @@ inline PhenoGenoStats statsFromGVec(
             indexForMissing.push_back(i);
     }
     PhenoGenoStats s;
+    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         s.altFreq = NAN;
@@ -447,6 +454,7 @@ inline void extractAndStatsBatched(
     for (size_t p = 0; p < K; ++p) {
         const uint32_t nonMissing = acc[p].nHomRef + acc[p].nHet + acc[p].nHomAlt;
         PhenoGenoStats &s = outStats[p];
+        s.sumSq = static_cast<double>(acc[p].nHet) + 4.0 * static_cast<double>(acc[p].nHomAlt);
         if (nonMissing == 0) {
             s.altFreq = NAN;
             s.mac = NAN;
@@ -512,6 +520,7 @@ inline PhenoGenoStats sparseExtractAndStats(
 
     // Compute stats from counts
     PhenoGenoStats s;
+    s.sumSq = static_cast<double>(counts[1]) + 4.0 * static_cast<double>(counts[2]);
     const uint32_t nonMissing = counts[0] + counts[1] + counts[2];
     if (nonMissing == 0) {
         s.altFreq = NAN;

--- a/src/io/sparse_grm.cpp
+++ b/src/io/sparse_grm.cpp
@@ -5,7 +5,9 @@
 #include "util/text_scanner.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -95,13 +97,31 @@ std::vector<std::string> SparseGRM::readGctaIIDs(const std::string &spFile) {
     std::vector<std::string> iids;
     iids.reserve(65536);
     std::string line;
+    int iidCol = -1; // 0 = IID-only, 1 = FID+IID; auto-detected from first row
     while (std::getline(idStream, line)) {
         if (!line.empty() && line.back() == '\r') line.pop_back();
         if (line.empty()) continue;
+
         text::TokenScanner tok(line);
-        /*FID*/ tok.next();
-        std::string iid = tok.next();
-        if (iid.empty()) throw std::runtime_error(idFile + ": missing IID on line " + std::to_string(iids.size() + 1));
+        std::string tok1 = tok.next();
+        if (tok1.empty()) continue; // whitespace-only line
+        std::string tok2 = tok.next();
+
+        if (iidCol < 0) {
+            iidCol = tok2.empty() ? 0 : 1;
+            if (iidCol == 0)
+                infoMsg("%s: detected IID-only format (1 column)", idFile.c_str());
+            else
+                infoMsg("%s: detected FID+IID format; using IID column, ignoring FID", idFile.c_str());
+        } else if ((iidCol == 0 && !tok2.empty()) || (iidCol == 1 && tok2.empty())) {
+            throw std::runtime_error(idFile + ": inconsistent column count on line " +
+                                     std::to_string(iids.size() + 1) +
+                                     " (expected " + (iidCol == 0 ? "1" : "≥2") + " columns)");
+        }
+
+        std::string iid = (iidCol == 0) ? std::move(tok1) : std::move(tok2);
+        if (iid.empty())
+            throw std::runtime_error(idFile + ": missing IID on line " + std::to_string(iids.size() + 1));
         iids.push_back(std::move(iid));
     }
     return iids;
@@ -214,9 +234,17 @@ SparseGRM SparseGRM::fromGCTA(
 }
 
 void SparseGRM::buildDiagonal() {
-    m_diagonal.assign(m_nSubj, 0.0);
+    constexpr double kNoDiag = std::numeric_limits<double>::quiet_NaN();
+    m_diagonal.assign(m_nSubj, kNoDiag);
     for (const auto &e : m_entries) {
         if (e.row == e.col && e.row < m_nSubj) m_diagonal[e.row] = e.value;
+    }
+    uint32_t missing = 0;
+    for (double d : m_diagonal) if (std::isnan(d)) ++missing;
+    if (missing > 0) {
+        throw std::runtime_error("SparseGRM: " + std::to_string(missing) +
+                                 " of " + std::to_string(m_nSubj) +
+                                 " subjects have no diagonal entry");
     }
 }
 
@@ -284,6 +312,18 @@ SparseGRM SparseGRM::load(
     const std::vector<std::string> &subjectOrder,
     const std::vector<std::string> &famIIDs
 ) {
+    // No GRM provided → identity (diag = 1, no off-diag); assumes unrelated subjects.
+    if (grabFile.empty() && gctaFile.empty()) {
+        SparseGRM g;
+        g.m_nSubj = static_cast<uint32_t>(subjectOrder.size());
+        g.m_entries.reserve(g.m_nSubj);
+        for (uint32_t i = 0; i < g.m_nSubj; ++i)
+            g.m_entries.push_back({i, i, 1.0});
+        g.m_diagonal.assign(g.m_nSubj, 1.0);
+        infoMsg("Sparse GRM: no file provided, using identity GRM (diag=1.0, no off-diag) for %u subjects",
+                g.m_nSubj);
+        return g;
+    }
     if (!gctaFile.empty()) return fromGCTA(gctaFile, subjectOrder, famIIDs);
     return SparseGRM(grabFile, subjectOrder);
 }
@@ -309,6 +349,9 @@ std::unordered_set<std::string> SparseGRM::parseSubjectIDs(
     const std::vector<std::string> &famIIDs
 ) {
     std::unordered_set<std::string> ids;
+
+    // No GRM file: caller will use identity GRM downstream — no subject filtering.
+    if (grabFile.empty() && gctaFile.empty()) return ids;
 
     if (!gctaFile.empty()) {
         // ── GCTA format: read .grm.id ──────────────────────────────────

--- a/src/io/sparse_grm.hpp
+++ b/src/io/sparse_grm.hpp
@@ -96,7 +96,9 @@ class SparseGRM {
     }
 
     // Cached diagonal of G (self-relatedness per subject).
-    // diagonal()[i] == G(i,i).  Default 0.0 if subject has no diagonal entry.
+    // diagonal()[i] == G(i,i).  Loader throws if any subject has no
+    // diagonal entry — every subject in subjectOrder must have an
+    // explicit (i, i, value) row in the input file.
     const std::vector<double> &diagonal() const {
         return m_diagonal;
     }

--- a/src/spagrm/spagrm.hpp
+++ b/src/spagrm/spagrm.hpp
@@ -302,10 +302,12 @@ class SPAGRMMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) override {
+        (void)gSumSqs;   // SPAGRM uses theoretical 2p(1-p); empirical Σv² unused
         const int B = static_cast<int>(scores.cols());
         results.resize(B);
         const double residSum = m_spagrm.residSum();

--- a/src/spasqr/conquer.cpp
+++ b/src/spasqr/conquer.cpp
@@ -129,7 +129,9 @@ Eigen::VectorXd huberReg(
     double tol,
     double constTau,
     int iteMax,
-    double stepMax
+    double stepMax,
+    int *iterOut = nullptr,
+    double *finalGradNormOut = nullptr
 ) {
     double rob = constTau * eigMad(Y);
     updateHuber(Z, Y, tau, der, gradOld, n, rob, n1);
@@ -157,6 +159,8 @@ Eigen::VectorXd huberReg(
         gradDiff = gradNew - gradOld;
         ++ite;
     }
+    if (iterOut) *iterOut = ite;
+    if (finalGradNormOut) *finalGradNormOut = gradNew.lpNorm<Eigen::Infinity>();
     return beta;
 }
 
@@ -174,7 +178,8 @@ Eigen::VectorXd smqrGauss(
     Eigen::VectorXd *residOut,
     double tol,
     int iteMax,
-    double stepMax
+    double stepMax,
+    ConquerStatus *statusOut
 ) {
     const int n = static_cast<int>(X.rows());
     const int p = static_cast<int>(X.cols());
@@ -206,7 +211,10 @@ Eigen::VectorXd smqrGauss(
     Eigen::VectorXd der(n), gradOld(p + 1), gradNew(p + 1);
 
     // Phase 1: Huber initialization
-    Eigen::VectorXd beta = huberReg(Z, Yc, tau, der, gradOld, gradNew, n, p, n1, tol, constTau, iteMax, stepMax);
+    int huberIter = 0;
+    double huberFinalGradNorm = 0.0;
+    Eigen::VectorXd beta = huberReg(Z, Yc, tau, der, gradOld, gradNew, n, p, n1, tol, constTau, iteMax, stepMax,
+                                    &huberIter, &huberFinalGradNorm);
 
     // Quantile intercept adjustment
     Eigen::VectorXd resNoIntercept = Yc - Z.rightCols(p) * beta.tail(p);
@@ -239,11 +247,23 @@ Eigen::VectorXd smqrGauss(
         ++ite;
     }
 
+    const double gaussFinalGradNorm = gradNew.lpNorm<Eigen::Infinity>();
+
     // Un-standardize coefficients
     beta.tail(p).array() *= sx.array();
     beta(0) += my - (mx.array() * beta.tail(p).transpose().array()).sum();
 
     if (residOut) *residOut = res;
+
+    if (statusOut) {
+        statusOut->huberIter = huberIter;
+        statusOut->huberConverged = (huberFinalGradNorm <= tol) && (huberIter <= iteMax);
+        statusOut->huberFinalGradNorm = huberFinalGradNorm;
+        statusOut->gaussIter = ite;
+        statusOut->gaussConverged = (gaussFinalGradNorm <= tol) && (ite <= iteMax);
+        statusOut->gaussFinalGradNorm = gaussFinalGradNorm;
+        statusOut->converged = statusOut->huberConverged && statusOut->gaussConverged;
+    }
 
     return beta;
 }

--- a/src/spasqr/conquer.hpp
+++ b/src/spasqr/conquer.hpp
@@ -15,6 +15,21 @@
 
 namespace conquer {
 
+// Per-fit convergence diagnostics for smqrGauss.
+//
+// `converged` is true iff BOTH the Huber init phase and the Gaussian
+// smoothed phase reached the gradient tolerance within their iteration
+// budgets.  The per-phase fields let callers diagnose which phase failed.
+struct ConquerStatus {
+    bool   converged          = false; // both phases met tol
+    int    huberIter          = 0;     // iterations used in Phase 1 (Huber init)
+    bool   huberConverged     = false;
+    double huberFinalGradNorm = 0.0;   // final ||grad||_∞ of Phase 1
+    int    gaussIter          = 0;     // iterations used in Phase 2 (Gaussian smoothed)
+    bool   gaussConverged     = false;
+    double gaussFinalGradNorm = 0.0;   // final ||grad||_∞ of Phase 2
+};
+
 // Run smoothed quantile regression for a single tau.
 //
 //   X  : n × p  design matrix (raw covariates, NOT including intercept)
@@ -24,6 +39,10 @@ namespace conquer {
 //
 // Returns (p+1) coefficient vector:  beta(0) = intercept,  beta(1..p) = slopes.
 // Also stores the final n-vector of residuals in `residOut` if non-null.
+//
+// If `statusOut` is non-null, populates it with per-phase convergence info.
+// The function never throws on non-convergence — callers must check
+// `statusOut->converged` and decide how to react.
 Eigen::VectorXd smqrGauss(
     const Eigen::MatrixXd &X,
     const Eigen::VectorXd &Y,
@@ -32,7 +51,8 @@ Eigen::VectorXd smqrGauss(
     Eigen::VectorXd *residOut = nullptr,
     double tol = 1e-7,
     int iteMax = 5000,
-    double stepMax = 100.0
+    double stepMax = 100.0,
+    ConquerStatus *statusOut = nullptr
 );
 
 } // namespace conquer

--- a/src/spasqr/spasqr.cpp
+++ b/src/spasqr/spasqr.cpp
@@ -370,15 +370,17 @@ struct SPAsqrSPAShared {
 };
 
 // ── Per-tau p-value (replaces SPAGRMClass::getMarkerPvalFromScore) ──
+// G_var = empirical Var(G) from the caller (post-imputation, per-pheno).
+// MAF kept for SPA CGF (binomial structural assumption); not used for variance.
 inline double scalarGetPvalFromScore(
     double Score,
     double altFreq,
+    double G_var,
     double &zScore,
     const SPAsqrPerTau &tau,
     const SPAsqrSPAShared &spa
 ) {
     const double MAF       = std::min(altFreq, 1.0 - altFreq);
-    const double G_var     = 2.0 * MAF * (1.0 - MAF);
     const double Score_var = G_var * tau.R_GRM_R;
 
     if (Score_var <= 0.0 || MAF <= 0.0) {
@@ -417,14 +419,16 @@ inline double scalarGetPvalFromScore(
 // Computes the SPA p-value for a marker that failed the normal-approx
 // cutoff.  Both tails share the MAF/variance setup and outlier data
 // pointer extraction; only the Newton root and saddlepoint differ.
+// G_var = empirical Var(G) from caller; ratio EmpVar/Score_var is invariant
+// to the choice of variance, so SPA tails behave the same as before.
 inline double fusedGetPvalSpa(
     double Score,
     double altFreq,
+    double G_var,
     const SPAsqrPerTau &tau,
     const SPAsqrSPAShared &spa
 ) {
     const double MAF       = std::min(altFreq, 1.0 - altFreq);
-    const double G_var     = 2.0 * MAF * (1.0 - MAF);
     const double Score_var = G_var * tau.R_GRM_R;
 
     const double EmpVar    = G_var * (tau.R_GRM_R_nonOutlier + tau.sum_unrelated_outliers2);
@@ -532,12 +536,17 @@ class SPAsqrMethod : public MethodBase {
         result.clear();
         result.reserve(2 * m_ntaus + 1);
 
-        const double gMean = GVec.mean();
+        const double n      = static_cast<double>(GVec.size());
+        const double gSum   = GVec.sum();
+        const double gSumSq = GVec.squaredNorm();
+        const double gMean  = gSum / n;
+        const double G_var  = (gSumSq - gSum * gSum / n) / (n - 1.0);
+
         Eigen::VectorXd scores = m_methodShared->residMat.transpose() * GVec;
         for (int i = 0; i < m_ntaus; ++i)
             scores[i] -= gMean * m_methodShared->residSums[i];
 
-        processOneMarker(scores.data(), altFreq, result);
+        processOneMarker(scores.data(), altFreq, G_var, result);
     }
 
     // ── Batched analysis: B markers at once ────────────────────────────
@@ -555,8 +564,14 @@ class SPAsqrMethod : public MethodBase {
         const Eigen::VectorXd gMeans = GBatch.colwise().mean();
         scoreMatrix.noalias() -= m_methodShared->residSums * gMeans.transpose();
 
-        for (int b = 0; b < B; ++b)
-            processOneMarker(scoreMatrix.col(b).data(), altFreqs[b], results[b]);
+        const double n  = static_cast<double>(GBatch.rows());
+        const double n1 = n - 1.0;
+        for (int b = 0; b < B; ++b) {
+            const double gSum   = GBatch.col(b).sum();
+            const double gSumSq = GBatch.col(b).squaredNorm();
+            const double G_var  = (gSumSq - gSum * gSum / n) / n1;
+            processOneMarker(scoreMatrix.col(b).data(), altFreqs[b], G_var, results[b]);
+        }
     }
 
     int preferredBatchSize() const override {
@@ -593,6 +608,7 @@ class SPAsqrMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
@@ -602,7 +618,9 @@ class SPAsqrMethod : public MethodBase {
 
         // ── Center scores ──────────────────────────────────────────
         m_centeredBuf = scores;
-        const double invN = 1.0 / static_cast<double>(nUsed);
+        const double n    = static_cast<double>(nUsed);
+        const double n1   = n - 1.0;
+        const double invN = 1.0 / n;
         for (int b = 0; b < B; ++b) {
             const double gMean = gSums[b] * invN;
             for (int t = 0; t < m_ntaus; ++t)
@@ -624,7 +642,11 @@ class SPAsqrMethod : public MethodBase {
                 const double Score   = m_centeredBuf(t, b);
                 const double altFreq = altFreqs[b];
                 const double MAF     = std::min(altFreq, 1.0 - altFreq);
-                const double G_var   = 2.0 * MAF * (1.0 - MAF);
+                // Empirical Var(G) on the post-imputation, per-pheno column.
+                // gSums / gSumSqs come from the engine after Phase-1b imputation.
+                const double gSum    = gSums[b];
+                const double gSumSq  = gSumSqs[b];
+                const double G_var   = (gSumSq - gSum * gSum * invN) / n1;
                 const double Svar    = G_var * tau.R_GRM_R;
 
                 double z, p;
@@ -640,7 +662,7 @@ class SPAsqrMethod : public MethodBase {
                         p = 2.0 * math::pnorm(std::abs(z), 0.0, 1.0, false);
                     } else {
                         // Slow path: C3 fused upper+lower SPA
-                        p = fusedGetPvalSpa(Score, altFreq, tau, *m_spaShared);
+                        p = fusedGetPvalSpa(Score, altFreq, G_var, tau, *m_spaShared);
                     }
                 }
                 zBuf[b * m_ntaus + t] = z;
@@ -708,6 +730,7 @@ class SPAsqrMethod : public MethodBase {
     void processOneMarker(
         const double *centeredScores,
         double altFreq,
+        double G_var,
         std::vector<double> &result
     ) {
         result.clear();
@@ -719,7 +742,7 @@ class SPAsqrMethod : public MethodBase {
 
         for (int i = 0; i < m_ntaus; ++i) {
             double z;
-            double p = scalarGetPvalFromScore(centeredScores[i], altFreq, z,
+            double p = scalarGetPvalFromScore(centeredScores[i], altFreq, G_var, z,
                                               m_spaShared->perTau[i], *m_spaShared);
             zScores[i] = z;
             pvals[i] = p;
@@ -1108,8 +1131,18 @@ void runSPAsqr(
 
             try {
                 Eigen::VectorXd resid;
-                Eigen::VectorXd beta = conquer::smqrGauss(pw[k].X, pw[k].Y, taus[t], pw[k].h, &resid, spasqrTol);
+                conquer::ConquerStatus st;
+                Eigen::VectorXd beta = conquer::smqrGauss(pw[k].X, pw[k].Y, taus[t], pw[k].h, &resid, spasqrTol,
+                                                          5000, 100.0, &st);
                 infoMsg("[%s] tau=%.4f intercept=%.6f", phenoNames[k].c_str(), taus[t], beta(0));
+                if (!st.converged) {
+                    warnMsg("[%s] tau=%.4f conquer did not converge: huber=%d iters (||g||=%.3e, %s),"
+                            " gauss=%d iters (||g||=%.3e, %s); tol=%.3e",
+                            phenoNames[k].c_str(), taus[t],
+                            st.huberIter, st.huberFinalGradNorm, st.huberConverged ? "ok" : "FAIL",
+                            st.gaussIter, st.gaussFinalGradNorm, st.gaussConverged ? "ok" : "FAIL",
+                            spasqrTol);
+                }
 
                 const Eigen::Index Nk = static_cast<Eigen::Index>(pw[k].nk);
                 for (Eigen::Index i = 0; i < Nk; ++i)
@@ -1221,11 +1254,16 @@ void runSPAsqr(
 // ══════════════════════════════════════════════════════════════════════
 // runSPAsqrLoco — LOCO entry point
 //
-// Matches the serial workflow (2.serial_loco.sh):
-//   - conquer fits are chromosome-independent (same Y, same X)
-//   - per-phenotype bandwidth h
-//   - SPAsqrMethod built once per phenotype, cloned per chromosome
-//   - locoEngine iterates chromosomes, testing each chromosome's markers
+// Per-chromosome workflow:
+//   - For each chromosome, the buildTasks callback rebuilds the conquer fits
+//     based on that chromosome's LOCO PRS column.
+//   - Both modes feed conquer with X = pw[k].baseX (original covariates only,
+//     no LOCO augmentation) and y_adj computed per chromosome:
+//       offset    → y_adj = IRN(y_raw) - loco_chr     (β=1, α=0; IRN once before loop)
+//       covariate → y_adj = y_raw - α̂ - β̂·loco_chr   (per-chr OLS partial-out, raw y)
+//   - Per-chr bandwidth h_chr[k] = IQR(y_adj) / scale in BOTH modes (chr-specific).
+//   - locoEngine iterates chromosomes, testing each chromosome's markers via
+//     the multi-phenotype work-stealing engine.
 // ══════════════════════════════════════════════════════════════════════
 
 void runSPAsqrLoco(
@@ -1254,7 +1292,8 @@ void runSPAsqrLoco(
     double spasqrH,
     double spasqrHScale,
     const std::string &keepFile,
-    const std::string &removeFile
+    const std::string &removeFile,
+    const std::string &locoMode
 ) {
     const int K = static_cast<int>(phenoNames.size());
     const int ntaus = static_cast<int>(taus.size());
@@ -1263,6 +1302,7 @@ void runSPAsqrLoco(
     // Union = subjects with genotype ∩ GRM ∩ keep/remove.  Per-phenotype
     // NA filtering is deferred — each phenotype uses its own non-missing
     // subset of the union.
+    infoMsg("SPAsqr-LOCO mode: %s", locoMode.c_str());
     infoMsg("SPAsqr-LOCO: Loading phenotype and covariate data (%d phenotypes, %d taus)", K, ntaus);
     auto famIIDs = parseGenoIIDs(geno);
     SubjectData sd(std::move(famIIDs));
@@ -1317,6 +1357,14 @@ void runSPAsqrLoco(
             if (nCov > 0) pw[k].baseX.row(li) = unionX.row(i);
         }
 
+        // In offset mode, replace Y with its inverse-rank-normal
+        // transform (per-phenotype non-missing scope, Blom plotting position,
+        // average-rank ties).  All downstream math (bandwidth, conquer fit,
+        // y_adj per chromosome) operates on the IRN'd Y.
+        if (locoMode == "offset") {
+            pw[k].Y = math::inverseRankNormal(pw[k].Y);
+        }
+
         // Per-phenotype bandwidth
         if (spasqrH >= 0.0) {
             pw[k].h = spasqrH;
@@ -1340,17 +1388,23 @@ void runSPAsqrLoco(
     }
 
     // Log N/bandwidth table
+    // Both modes compute per-chr h_chr = IQR(y_adj)/scale inside the chr loop;
+    // the value shown here is the GLOBAL reference h derived from IQR(pw[k].Y)
+    // (= IQR(Y_irn) in offset, IQR(Y_raw) in covariate). Actual per-chr h is
+    // logged via "SPAsqr-LOCO chr%s [...]: per-chr h = ...".
     {
+        const char *bwLabel = "global_h(ref)";
         infoMsg("Sample size and smooth bandwidth per phenotype:");
         size_t nameW = 4;
         for (int k = 0; k < K; ++k)
             nameW = std::max(nameW, phenoNames[k].size());
         nameW += 2;
         char row[256];
-        std::snprintf(row, sizeof(row), "    %-*s %10s %12s\n", static_cast<int>(nameW), "", "N", "bandwidth");
+        std::snprintf(row, sizeof(row), "    %-*s %10s %14s\n",
+                      static_cast<int>(nameW), "", "N", bwLabel);
         fprintf(stderr, "%s", row);
         for (int k = 0; k < K; ++k) {
-            std::snprintf(row, sizeof(row), "    %-*s %10u %12.6f\n",
+            std::snprintf(row, sizeof(row), "    %-*s %10u %14.6f\n",
                           static_cast<int>(nameW), phenoNames[k].c_str(), pw[k].nk, pw[k].h);
             fprintf(stderr, "%s", row);
         }
@@ -1381,25 +1435,93 @@ void runSPAsqrLoco(
         phenoGrms[k] = reindexGrm(unionGrm, pw[k].unionToLocal, nUnion);
 
     // ── 7. Build LocoTaskBuilder callback ──────────────────────────
-    // For each chromosome, augment base covariates with the LOCO column
-    // (mapped to pheno-dense space), run K × ntaus conquer fits, and
-    // build K SPAsqrMethods.
+    // For each chromosome, build per-pheno y_adj (mode-dependent), run
+    // K × ntaus conquer fits with X = baseX, and build K SPAsqrMethods.
     auto buildTasks = [&](const std::string &chr, std::vector<PhenoTask> &tasks) {
         tasks.resize(K);
 
-        // Augment base covariates with LOCO column per phenotype (pheno-dense)
-        std::vector<Eigen::MatrixXd> X_augs(K);
+        // Both modes feed conquer with X = pw[k].baseX. Only y_adj differs:
+        //   offset    → y_adj = pw[k].Y(IRN'd) - loco_chr_pheno_dense        (β=1, α=0)
+        //   covariate → y_adj = pw[k].Y(raw)   - α̂ - β̂·loco_chr_pheno_dense  (per-chr OLS)
+        // Per-chr bandwidth h_chr[k] = IQR(y_adj) / scale in both modes.
+        std::vector<Eigen::VectorXd> y_adjs(K);
+        std::vector<double> h_chr(K, 0.0);
+
         for (int k = 0; k < K; ++k) {
             const Eigen::Index Nk = static_cast<Eigen::Index>(pw[k].nk);
-            X_augs[k].resize(Nk, nCov + 1);
-            X_augs[k].leftCols(nCov) = pw[k].baseX;
-            // Extract LOCO scores from union to pheno-dense space
+
+            // Map LOCO scores from union → pheno-dense (Nk-length) space.
             const auto &locoVec = loco.scores.at(phenoNames[k]).at(chr);
+            Eigen::VectorXd loco_dense(Nk);
             for (uint32_t i = 0; i < nUnion; ++i) {
                 uint32_t li = pw[k].unionToLocal[i];
                 if (li != UINT32_MAX)
-                    X_augs[k](li, nCov) = locoVec[i];
+                    loco_dense[li] = locoVec[i];
             }
+
+            // Compute y_adj per mode.
+            if (locoMode == "offset") {
+                // Raw subtraction of loco from IRN'd Y (pw[k].Y already IRN'd in §3).
+                y_adjs[k] = pw[k].Y - loco_dense;
+            } else { // covariate
+                // OLS y_raw ~ 1 + loco_dense  (pw[k].Y stays raw — IRN is offset-only).
+                const double y_mean = pw[k].Y.mean();
+                const double l_mean = loco_dense.mean();
+                const Eigen::ArrayXd y_dev = pw[k].Y.array() - y_mean;
+                const Eigen::ArrayXd l_dev = loco_dense.array() - l_mean;
+                const double l_var = l_dev.square().sum();
+                double beta_hat  = 0.0;
+                double alpha_hat = y_mean;
+                if (l_var > 0.0) {
+                    beta_hat  = (y_dev * l_dev).sum() / l_var;
+                    alpha_hat = y_mean - beta_hat * l_mean;
+                }
+                y_adjs[k] = pw[k].Y.array() - alpha_hat - beta_hat * loco_dense.array();
+                infoMsg("SPAsqr-LOCO chr%s [%s] covariate: OLS partial-out alpha=%.6f beta=%.6f",
+                        chr.c_str(), phenoNames[k].c_str(), alpha_hat, beta_hat);
+            }
+
+            // Diagnostic: corr(Y, loco_chr)^2 in pheno-dense space.
+            // Y here = pw[k].Y (IRN'd in offset mode, raw in covariate mode).
+            double r2_loco = 0.0;
+            {
+                const double mean_y = pw[k].Y.mean();
+                const double mean_l = loco_dense.mean();
+                const Eigen::ArrayXd dev_y = pw[k].Y.array() - mean_y;
+                const Eigen::ArrayXd dev_l = loco_dense.array() - mean_l;
+                const double cov_yl  = (dev_y * dev_l).sum();
+                const double var_y   = dev_y.square().sum();
+                const double var_l   = dev_l.square().sum();
+                if (var_y > 0.0 && var_l > 0.0)
+                    r2_loco = (cov_yl * cov_yl) / (var_y * var_l);
+            }
+
+            // Per-chromosome bandwidth from IQR(y_adj).  --spasqr-h overrides auto-IQR.
+            if (spasqrH >= 0.0) {
+                h_chr[k] = spasqrH;
+            } else {
+                std::vector<double> ysorted(static_cast<size_t>(Nk));
+                Eigen::VectorXd::Map(ysorted.data(), Nk) = y_adjs[k];
+                std::sort(ysorted.begin(), ysorted.end());
+                auto quant = [&](double prob) -> double {
+                    double idx = prob * (Nk - 1);
+                    Eigen::Index lo = static_cast<Eigen::Index>(std::floor(idx));
+                    Eigen::Index hi = std::min(lo + 1, Nk - 1);
+                    double frac = idx - lo;
+                    return ysorted[lo] * (1.0 - frac) + ysorted[hi] * frac;
+                };
+                double iqr = quant(0.75) - quant(0.25);
+                double scale = (spasqrHScale >= 0.0) ? spasqrHScale : 3.0;
+                h_chr[k] = iqr / scale;
+                if (h_chr[k] <= 0.0)
+                    h_chr[k] = std::max(std::pow((std::log(Nk) + nCov) / static_cast<double>(Nk), 0.4), 0.05);
+            }
+
+            const char *yLabel = (locoMode == "offset") ? "Y_irn" : "Y_raw";
+            infoMsg("SPAsqr-LOCO chr%s [%s][%s]: per-chr h = IQR(y_adj)/scale = %.6f (Nk=%u),"
+                    " corr(%s, loco)^2 = %.4f",
+                    chr.c_str(), phenoNames[k].c_str(), locoMode.c_str(),
+                    h_chr[k], pw[k].nk, yLabel, r2_loco);
         }
 
         // Parallel conquer fits: K × ntaus
@@ -1421,11 +1543,25 @@ void runSPAsqrLoco(
                 if (idx >= totalFits) break;
                 int k = idx / ntaus;
                 int t = idx % ntaus;
-                const double h1 = 1.0 / pw[k].h;
+                const double h_use = h_chr[k];
+                const double h1    = 1.0 / h_use;
 
                 try {
                     Eigen::VectorXd resid;
-                    conquer::smqrGauss(X_augs[k], pw[k].Y, taus[t], pw[k].h, &resid, spasqrTol);
+                    conquer::ConquerStatus st;
+                    // Both modes: SQR on (baseX, y_adjs[k]).
+                    //   offset    → y_adjs[k] = IRN(y) - loco_chr
+                    //   covariate → y_adjs[k] = y_raw - α̂ - β̂·loco_chr   (per-chr OLS partial-out)
+                    conquer::smqrGauss(pw[k].baseX, y_adjs[k], taus[t], h_use, &resid, spasqrTol,
+                                       5000, 100.0, &st);
+                    if (!st.converged) {
+                        warnMsg("[%s] chr%s tau=%.4f conquer did not converge: huber=%d iters (||g||=%.3e, %s),"
+                                " gauss=%d iters (||g||=%.3e, %s); tol=%.3e",
+                                phenoNames[k].c_str(), chr.c_str(), taus[t],
+                                st.huberIter, st.huberFinalGradNorm, st.huberConverged ? "ok" : "FAIL",
+                                st.gaussIter, st.gaussFinalGradNorm, st.gaussConverged ? "ok" : "FAIL",
+                                spasqrTol);
+                    }
 
                     const Eigen::Index Nk = static_cast<Eigen::Index>(pw[k].nk);
                     for (Eigen::Index i = 0; i < Nk; ++i)

--- a/src/spasqr/spasqr.hpp
+++ b/src/spasqr/spasqr.hpp
@@ -104,5 +104,6 @@ void runSPAsqrLoco(
     double spasqrH = -1.0,
     double spasqrHScale = -1.0,
     const std::string &keepFile = {},
-    const std::string &removeFile = {}
+    const std::string &removeFile = {},
+    const std::string &locoMode = "offset"
 );

--- a/src/util/logging.hpp
+++ b/src/util/logging.hpp
@@ -10,21 +10,45 @@
 #include <ctime>
 #include <mutex>
 
+namespace logging_detail {
+inline std::mutex &mutex() {
+    static std::mutex m;
+    return m;
+}
+
+inline void writeStamped(const char *level, const char *msg) {
+    std::lock_guard<std::mutex> lk(mutex());
+    auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    char ts[20];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
+    std::fprintf(stderr, "[%s] %s %s\n", level, ts, msg);
+}
+} // namespace logging_detail
+
 // Function-local static ensures the mutex is initialized exactly once
 // even across translation units (C++17 magic statics are thread-safe).
 inline void infoMsg(
     const char *fmt,
     ...
 ) {
-    static std::mutex s_logMutex;
     char buf[512];
     va_list args;
     va_start(args, fmt);
     std::vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
-    std::lock_guard<std::mutex> lk(s_logMutex);
-    auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    char ts[20];
-    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
-    std::fprintf(stderr, "[INFO] %s %s\n", ts, buf);
+    logging_detail::writeStamped("INFO", buf);
+}
+
+// Same shape as infoMsg, but tagged [WARN] for non-fatal anomalies the user
+// should notice (e.g. solver failed to converge, fell back to a default).
+inline void warnMsg(
+    const char *fmt,
+    ...
+) {
+    char buf[512];
+    va_list args;
+    va_start(args, fmt);
+    std::vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    logging_detail::writeStamped("WARN", buf);
 }

--- a/src/util/math_helper.cpp
+++ b/src/util/math_helper.cpp
@@ -286,4 +286,32 @@ OptimResult nelderMead(
     return {simplex[ilo], fvals[ilo], iter};
 }
 
+// § 5  Inverse rank normal transform (Blom, average-rank ties)
+
+Eigen::VectorXd inverseRankNormal(const Eigen::Ref<const Eigen::VectorXd> &y) {
+    const Eigen::Index N = y.size();
+    if (N == 0) throw std::runtime_error("inverseRankNormal: empty input");
+
+    std::vector<Eigen::Index> idx(static_cast<size_t>(N));
+    for (Eigen::Index i = 0; i < N; ++i) idx[static_cast<size_t>(i)] = i;
+    std::stable_sort(idx.begin(), idx.end(),
+                     [&](Eigen::Index a, Eigen::Index b) { return y[a] < y[b]; });
+
+    Eigen::VectorXd out(N);
+    const double denom = static_cast<double>(N) + 0.25;
+
+    Eigen::Index i = 0;
+    while (i < N) {
+        Eigen::Index j = i + 1;
+        while (j < N && y[idx[static_cast<size_t>(j)]] == y[idx[static_cast<size_t>(i)]]) ++j;
+        // 1-based ranks i+1 .. j ; midpoint = (i+1 + j) / 2.
+        const double avgRank = (static_cast<double>(i + 1) + static_cast<double>(j)) * 0.5;
+        const double p = (avgRank - 0.375) / denom;
+        const double z = qnorm(p);
+        for (Eigen::Index k = i; k < j; ++k) out[idx[static_cast<size_t>(k)]] = z;
+        i = j;
+    }
+    return out;
+}
+
 } // namespace math

--- a/src/util/math_helper.hpp
+++ b/src/util/math_helper.hpp
@@ -282,6 +282,12 @@ Eigen::VectorXd logisticRegression(
     const Eigen::Ref<const Eigen::VectorXd> &y
 );
 
+// Inverse rank normal transform with Blom plotting position.
+//   p_i = (rank_i - 3/8) / (N + 1/4),  Y_irn[i] = qnorm(p_i)
+// Tied values get the average of their ranks (R `ties.method="average"`).
+// Input is assumed to be NaN-free (caller filters); throws on N == 0.
+Eigen::VectorXd inverseRankNormal(const Eigen::Ref<const Eigen::VectorXd> &y);
+
 // ──────────────────────────────────────────────────────────────────────
 // § 6  Nelder-Mead simplex optimiser (n-dimensional, unconstrained)
 // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Changes

1. LDAK-KVIK LOCO format support (src/engine/loco.cpp)

Added auto-detection of .loco file format per phenotype: Regenie (header starts with FID_IID, chromosome-major rows) vs LDAK-KVIK (header starts with FID IID Chr1 Chr2 ..., subject-major rows).
Renamed parseLocoFile() → parseRegenieLocoFile() for clarity.
Added parseLdakLocoFile(): parses the transposed LDAK-KVIK layout using mmap + strtod for zero-copy I/O, stripping Chr/chr prefixes and filtering to autosomes 1–22.
Format detection is per-phenotype, so the same pred.list can mix Regenie and LDAK-KVIK files.
2. SPAsqr-LOCO: new --loco-mode flag (offset | covariate)

offset (default): Inverse-rank-normal (IRN) transforms Y per phenotype once before the chromosome loop, then subtracts the per-chromosome LOCO PRS as an offset (y_adj = IRN(Y) − loco_chr). Conquer is fit with original covariates only.
covariate: Keeps Y raw; per-chromosome OLS partial-out of loco_chr (y_adj = Y − α̂ − β̂·loco_chr) before each conquer fit. Logs the per-chromosome α̂, β̂.
Per-chromosome bandwidth h_chr: Both modes now compute h_chr = IQR(y_adj) / scale per chromosome, replacing the previously global pw[k].h. --spasqr-h still overrides auto-IQR.
Diagnostic logging added: corr(Y, loco_chr)² and per-chr h_chr for every (chromosome, phenotype) pair.
CLI updated: --loco-mode flag wired through flags.hpp, parse.cpp, dispatch.cpp, and spasqr.cpp/spasqr.hpp.
3. Empirical genotype variance for SPAsqr (replaces 2·MAF·(1−MAF))

PhenoGenoStats gains a sumSq field (post-imputation Σ G²) computed in statsFromUnionVec, statsFromGVec, extractAndStatsBatched, and sparseExtractAndStats.
multiPhenoEngineRange collects a passGSumSqs vector alongside passGSums and passes it to processScoreBatch.
processScoreBatch interface gains a gSumSqs parameter (virtual base + all overrides updated).
SPAsqr (scalarGetPvalFromScore, fusedGetPvalSpa, processOneMarker, processScoreBatch) now computes G_var = (ΣG² − (ΣG)²/n) / (n−1) from the observed genotype values instead of the theoretical Hardy–Weinberg 2p(1−p). This gives a more accurate variance estimate after mean-imputation of missing genotypes.
SPAGRM's processScoreBatch ignores gSumSqs (still uses theoretical variance; marked with comment).
4. Conquer convergence diagnostics (src/spasqr/conquer.hpp, conquer.cpp)

New ConquerStatus struct: reports per-phase convergence (huberConverged, gaussConverged, converged), iteration counts, and final ‖grad‖∞ for both the Huber initialization phase and the Gaussian-smoothed phase.
smqrGauss() accepts an optional ConquerStatus *statusOut; never throws on non-convergence — callers decide how to handle it.
Both runSPAsqr and runSPAsqrLoco check st.converged and emit a warnMsg (non-fatal) with full per-phase details if either phase fails.
5. Inverse rank normal transform (src/util/math_helper.cpp, math_helper.hpp)

New math::inverseRankNormal(): Blom plotting position p = (rank − 3/8) / (N + 1/4), tied values get the average of their ranks (matches R's ties.method = "average"). Used in SPAsqr-LOCO offset mode.
6. Logging: warnMsg and shared mutex (src/util/logging.hpp)

Extracted timestamp/lock logic into logging_detail::writeStamped() shared by all log functions.
Added warnMsg() (same signature as infoMsg(), tagged [WARN]) for non-fatal anomalies users should notice.
Replaced per-function static std::mutex with a single shared mutex (avoids potential issues with multiple static mutexes in a multi-threaded context).
7. SPAsqr: optional sparse GRM (src/io/sparse_grm.cpp, sparse_grm.hpp, src/cli/dispatch.cpp)

--sp-grm-grab / --sp-grm-plink2 are now optional for SPAsqr (were required). When neither is provided, an identity GRM (diag = 1, no off-diagonal entries) is constructed, assuming unrelated subjects, with a warnMsg.
SparseGRM::load() and parseSubjectIDs() handle the no-file case gracefully.
SparseGRM::buildDiagonal() now throws if any subject has no diagonal entry (previously silently defaulted to 0.0).
readGctaIIDs() auto-detects IID-only (1 column) vs FID+IID (2 columns) GRM ID file format.
8. .gitignore updates

Ignore *.R files, .DS_Store, CLAUDE.md, and submit_smoketest.sh (local dev artifacts).