### PR TITLE
Cpp pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build_bak/
 tmp/
 examples/
 example_1kg/
+*.R

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp/
 examples/
 example_1kg/
 *.R
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ examples/
 example_1kg/
 *.R
 .DS_Store
+
+# macOS
+.DS_Store
+
+# local notes/scripts
+CLAUDE.md
+submit_smoketest.sh

--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,27 @@ else
   export TEMP := $(WIN_TMP)
 endif
 
-# ── AVX2 detection ────────────────────────────────────────────────────────────
-# Try to compile a small AVX2 test; if the compiler supports it, enable -mavx2.
-# Use a temp file as output target for portability (MSYS2/Windows lacks /dev/null for ld).
-AVX2_OK := $(shell TMP_AVX=$$(mktemp -u 2>/dev/null || echo __avx2_test__); \
-  echo 'int main(){return 0;}' | $(CXX) -x c++ -mavx2 - -o "$$TMP_AVX" 2>/dev/null \
-  && { rm -f "$$TMP_AVX"; echo 1; } || rm -f "$$TMP_AVX")
-ifeq ($(AVX2_OK),1)
-  SIMD_FLAGS := -mavx2 -mbmi -mbmi2 -mlzcnt -mfma
+# ── Architecture detection ────────────────────────────────────────────────────
+# IS_X86 = 1 on x86_64; otherwise 0 (covers arm64/aarch64 macOS M-series, etc.).
+UNAME_M := $(shell uname -m 2>/dev/null)
+ifeq ($(UNAME_M),x86_64)
+  IS_X86 := 1
+else
+  IS_X86 := 0
+endif
+
+# ── AVX2 detection (x86 only) ─────────────────────────────────────────────────
+# Apple clang on ARM warns "-mavx2 unused" instead of erroring, so the probe
+# would falsely succeed.  Restrict the probe to x86 outright.
+ifeq ($(IS_X86),1)
+  AVX2_OK := $(shell TMP_AVX=$$(mktemp -u 2>/dev/null || echo __avx2_test__); \
+    echo 'int main(){return 0;}' | $(CXX) -x c++ -mavx2 - -o "$$TMP_AVX" 2>/dev/null \
+    && { rm -f "$$TMP_AVX"; echo 1; } || rm -f "$$TMP_AVX")
+  ifeq ($(AVX2_OK),1)
+    SIMD_FLAGS := -mavx2 -mbmi -mbmi2 -mlzcnt -mfma
+  else
+    SIMD_FLAGS :=
+  endif
 else
   SIMD_FLAGS :=
 endif
@@ -56,12 +69,12 @@ endif
 # __builtin_cpu_supports().  The baseline march must NOT include AVX2 so
 # that the scalar codepaths remain runnable on older x86-64 hardware.
 # Third-party code (pgenlib, bgen, htslib, …) keeps compile-time SIMD_FLAGS.
-UNAME_M := $(shell uname -m 2>/dev/null)
-ifeq ($(UNAME_M),x86_64)
+ifeq ($(IS_X86),1)
   # Default: native arch for best SIMD (AVX-512 on Zen 5, etc.).
   # Override with GRAB_MARCH=-march=x86-64-v2 for portable binaries.
   GRAB_MARCH := -march=native
 else
+  # ARM (arm64 / aarch64): rely on default tuning + scalar fallbacks.
   GRAB_MARCH :=
 endif
 
@@ -78,10 +91,13 @@ GRAB_CXXFLAGS := -std=c++17 -O3 -DNDEBUG $(GRAB_MARCH) $(PLATFORM_FLAGS) \
             -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare \
             -Wno-maybe-uninitialized
 CFLAGS   := -O3 -DNDEBUG $(PLATFORM_FLAGS) -ffunction-sections -fdata-sections $(SIMD_FLAGS)
-STATIC_LIBS := -static-libstdc++ -static-libgcc
+# Static libgcc/libstdc++: GCC/MinGW supports it for portable Linux/Windows
+# binaries; Apple clang on macOS doesn't accept these flags.
 ifeq ($(PLATFORM),macos)
+  STATIC_LIBS :=
   LDFLAGS := -Wl,-dead_strip -lpthread $(PLATFORM_LDLIBS) $(STATIC_LIBS)
 else
+  STATIC_LIBS := -static-libstdc++ -static-libgcc
   LDFLAGS := -Wl,--gc-sections -lpthread $(PLATFORM_LDLIBS) $(STATIC_LIBS)
 endif
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -40,7 +40,8 @@ struct Args {
     std::string admixTextPrefix;  // --admix-text-prefix
     std::string keepFile;         // --keep (subject include list)
     std::string removeFile;       // --remove (subject exclude list)
-    std::string predListFile;     // --pred-list (Regenie step 1 pred.list for LOCO)
+    std::string predListFile;     // --pred-list (Regenie / LDAK-KVIK pred.list for LOCO)
+    std::string locoMode = "offset"; // --loco-mode {offset, covariate}
     bool calAfCoef = false;
     bool calPairwiseIBD = false;
     bool calPhi = false;

--- a/src/cli/dispatch.cpp
+++ b/src/cli/dispatch.cpp
@@ -181,12 +181,17 @@ static void logArgsInEffect(const Args &args) {
             args.calAfCoef || args.method == "SPAmix" || args.method == "SPAmixPlus" || args.method == "LEAF";
         if (usesPcCols && !args.pcCols.empty()) std::fprintf(stderr, "  --pc-cols %s\n", args.pcCols.c_str());
     }
-    // spasqr-taus: relevant for SPAsqr pheno path
-    if (args.method == "SPAsqr" && !args.phenoName.empty() && !args.spasqrTaus.empty())std::fprintf(
-            stderr,
-            "  --spasqr-taus %s\n",
-            args.spasqrTaus.c_str()
-    );
+    // SPAsqr-specific knobs (relevant for SPAsqr pheno path)
+    if (args.method == "SPAsqr" && !args.phenoName.empty()) {
+        if (!args.spasqrTaus.empty())
+            std::fprintf(stderr, "  --spasqr-taus %s\n", args.spasqrTaus.c_str());
+        if (args.spasqrTol != 1e-7)
+            std::fprintf(stderr, "  --spasqr-tol %g\n", args.spasqrTol);
+        if (args.spasqrH >= 0.0)
+            std::fprintf(stderr, "  --spasqr-h %g\n", args.spasqrH);
+        if (args.spasqrHScale >= 0.0)
+            std::fprintf(stderr, "  --spasqr-h-scale %g\n", args.spasqrHScale);
+    }
     // other files
     if (!args.refAfFile.empty()) std::fprintf(stderr, "  --ref-af %s\n", args.refAfFile.c_str());
     if (!args.spGrmGrabFile.empty()) std::fprintf(stderr, "  --sp-grm-grab %s\n", args.spGrmGrabFile.c_str());
@@ -196,6 +201,11 @@ static void logArgsInEffect(const Args &args) {
     if (!args.extractFile.empty()) std::fprintf(stderr, "  --extract %s\n", args.extractFile.c_str());
     if (!args.excludeFile.empty()) std::fprintf(stderr, "  --exclude %s\n", args.excludeFile.c_str());
     if (!args.chrSpec.empty()) std::fprintf(stderr, "  --chr %s\n", args.chrSpec.c_str());
+    // LOCO (SPAsqr): only meaningful when --pred-list is given
+    if (!args.predListFile.empty()) {
+        std::fprintf(stderr, "  --pred-list %s\n", args.predListFile.c_str());
+        std::fprintf(stderr, "  --loco-mode %s\n", args.locoMode.c_str());
+    }
     if (!args.admixBfilePrefix.empty()) std::fprintf(stderr, "  --admix-bfile %s\n", args.admixBfilePrefix.c_str());
     if (!args.admixPhiFile.empty()) std::fprintf(stderr, "  --admix-phi %s\n", args.admixPhiFile.c_str());
     if (!args.mspFile.empty()) std::fprintf(stderr, "  --rfmix-msp %s\n", args.mspFile.c_str());
@@ -665,7 +675,11 @@ int run(
 
         // ── SPAsqr ─────────────────────────────────────────────────
         else if (args.method == "SPAsqr") {
-            checkSpGrm(args, /*required=*/ true, "SPAsqr");
+            checkSpGrm(args, /*required=*/ false, "SPAsqr");
+            if (args.spGrmGrabFile.empty() && args.spGrmPlink2File.empty()) {
+                warnMsg("SPAsqr: no --sp-grm-grab/--sp-grm-plink2 provided;"
+                        " falling back to identity GRM (assumes unrelated subjects)");
+            }
             if (args.phenoFile.empty() && args.covarFile.empty()) {
                 std::cerr << "Error: --pheno or --covar required for SPAsqr.\n";
                 return 1;
@@ -696,6 +710,11 @@ int run(
                 taus.push_back(t);
             }
             if (!args.predListFile.empty()) {
+                if (args.locoMode != "offset" && args.locoMode != "covariate") {
+                    std::cerr << "Error: --loco-mode must be 'offset' or 'covariate', got '"
+                              << args.locoMode << "'\n";
+                    return 1;
+                }
                 // Early validation: check all phenotypes have LOCO entries
                 {
                     std::ifstream pf(args.predListFile);
@@ -748,7 +767,8 @@ int run(
                     args.spasqrH,
                     args.spasqrHScale,
                     args.keepFile,
-                    args.removeFile
+                    args.removeFile,
+                    args.locoMode
                 );
             } else {
                 runSPAsqr(

--- a/src/cli/flags.hpp
+++ b/src/cli/flags.hpp
@@ -248,9 +248,24 @@ inline const FlagDef kRemove = {
 };
 
 inline const FlagDef kPredList = {
-    "--pred-list", "FILE", "Regenie step 1 pred.list file for LOCO analysis (phenoName locoPath per line)",
+    "--pred-list", "FILE", "pred.list file for LOCO analysis (phenoName locoPath per line; Regenie or LDAK-KVIK)",
     R"(Space-separated file with two columns: phenotype name and path to
-the corresponding .loco file from Regenie step 1.)"
+the corresponding .loco file. The .loco file format is auto-detected
+per phenotype: Regenie (header begins with FID_IID, chromosome-major
+rows) or LDAK-KVIK (header FID IID Chr1 Chr2 ... Chr22, subject-major
+rows).)"
+};
+
+inline const FlagDef kLocoMode = {
+    "--loco-mode", "MODE",
+    "How LOCO PRS enters SPAsqr-LOCO: offset (default) | covariate",
+    R"(Selects how the per-chromosome LOCO PRS is consumed:
+  offset    — inverse-rank-normal-transform Y per phenotype, then fit
+              conquer on (Y_irn - loco_chr) with the original covariates
+              only (LOCO subtracted from the response as an offset).
+  covariate — append the LOCO column to the conquer covariate matrix
+              and fit conquer on (Y, [X | loco_chr]).
+Only meaningful when --pred-list is provided.)"
 };
 
 inline const FlagDef kExtract = {
@@ -478,7 +493,7 @@ inline const FlagDef *const kSPAsqrOpt[] = {
     &kPhenoName,    &kSpasqrTaus, &kSpasqrTol,  &kSpasqrH,
     &kSpasqrHScale, &kOutlierIqr, &kOutlierAbs,
     &kSpaZThresh,   &kThreads,    &kChunkSize,  &kGeno, &kMaf,
-    &kMac,          &kHwe,        &kChr,        &kPredList,
+    &kMac,          &kHwe,        &kChr,        &kPredList,    &kLocoMode,
     nullptr
 };
 

--- a/src/cli/parse.cpp
+++ b/src/cli/parse.cpp
@@ -137,6 +137,7 @@ Args parseArgs(
         else if (arg == "--keep")a.keepFile = next();
         else if (arg == "--remove")a.removeFile = next();
         else if (arg == "--pred-list")a.predListFile = next();
+        else if (arg == "--loco-mode")a.locoMode = next();
         else if (arg == "--admix-bfile")a.admixBfilePrefix = next();
         else if (arg == "--admix-phi")a.admixPhiFile = next();
         else if (arg == "--rfmix-msp")a.mspFile = next();

--- a/src/engine/loco.cpp
+++ b/src/engine/loco.cpp
@@ -33,14 +33,31 @@ using namespace engine_impl;
 // LocoData — load Regenie step 1 LOCO predictions
 // ══════════════════════════════════════════════════════════════════════
 
-// Parse a .loco file directly into aligned vectors.
+// LOCO file format. Selected by header sniff in detectLocoFormat().
+enum class LocoFormat { Regenie, Ldak };
+
+// Detect format from the first whitespace-delimited token of the header.
+//   Regenie writes the literal joined token "FID_IID".
+//   LDAK-KVIK writes two separate tokens "FID" then "IID".
+static LocoFormat detectLocoFormat(const std::string &path) {
+    std::ifstream ifs(path);
+    if (!ifs.is_open())
+        throw std::runtime_error("Cannot open LOCO file for format detection: " + path);
+    std::string firstTok;
+    ifs >> firstTok;
+    if (firstTok.empty())
+        throw std::runtime_error("Empty LOCO file: " + path);
+    return (firstTok == "FID_IID") ? LocoFormat::Regenie : LocoFormat::Ldak;
+}
+
+// Parse a Regenie .loco file directly into aligned vectors.
 // Memory-maps the file and parses with strtod for zero-copy I/O —
 // avoids ifstream/getline overhead on multi-MB lines (400K columns).
 // Only autosomal chromosomes 1–22 are kept.
 //
 // Header: FID_IID  0_HG00096  0_HG00097  ...
 // Data:   1  0.0306  0.271  ...
-static std::unordered_map<std::string, Eigen::VectorXd>parseLocoFile(
+static std::unordered_map<std::string, Eigen::VectorXd>parseRegenieLocoFile(
     const std::string &path,
     const std::vector<std::string> &usedIIDs
 ) {
@@ -186,6 +203,160 @@ static std::unordered_map<std::string, Eigen::VectorXd>parseLocoFile(
     return result;
 }
 
+// Parse an LDAK-KVIK .loco file (transpose of Regenie layout).
+// Memory-mapped, zero-copy strtod, autosomes 1–22 only.
+//
+// Header: FID  IID  Chr1  Chr2  Chr3  ...  Chr22
+// Data:   U-2  U-2  0.6455  0.4759  ...  0.8893     (one row per subject)
+//
+// Chromosome labels are normalized: "Chr1" → "1", "Chr22" → "22"
+// so downstream chunk lookups match .bim/VCF/BGEN CHROM strings.
+static std::unordered_map<std::string, Eigen::VectorXd>parseLdakLocoFile(
+    const std::string &path,
+    const std::vector<std::string> &usedIIDs
+) {
+    int fd = ::open(path.c_str(), O_RDONLY);
+    if (fd < 0) throw std::runtime_error("Cannot open LOCO file: " + path);
+
+    struct stat st;
+    if (::fstat(fd, &st) != 0) {
+        ::close(fd);
+        throw std::runtime_error("Cannot stat LOCO file: " + path);
+    }
+    const size_t fileSize = static_cast<size_t>(st.st_size);
+    if (fileSize == 0) {
+        ::close(fd);
+        throw std::runtime_error("Empty LOCO file: " + path);
+    }
+
+    void *mapped = ::mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+    ::close(fd);
+    if (mapped == MAP_FAILED)
+        throw std::runtime_error("Cannot mmap LOCO file: " + path);
+    ::madvise(mapped, fileSize, MADV_SEQUENTIAL);
+
+    struct Guard { void *p; size_t n; ~Guard()
+                   {
+                       ::munmap(p, n);
+                   }
+
+    } guard{mapped, fileSize};
+
+    const char *p = static_cast<const char *>(mapped);
+    const char *const fend = p + fileSize;
+    const auto nUsed = static_cast<Eigen::Index>(usedIIDs.size());
+
+    auto skipWS = [&]() {
+                      while (p < fend && (*p == ' ' || *p == '\t')) ++p;
+                  };
+
+    auto readToken = [&](std::string &out) {
+                         out.clear();
+                         skipWS();
+                         while (p < fend && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
+                             out.push_back(*p++);
+                     };
+
+    // ── Header: expect "FID IID Chr1 Chr2 ... Chr22" ────────────────
+    std::string tok;
+    tok.reserve(32);
+
+    readToken(tok);
+    if (tok != "FID")
+        throw std::runtime_error("LDAK LOCO " + path + ": expected first header token 'FID', got '" + tok + "'");
+    readToken(tok);
+    if (tok != "IID")
+        throw std::runtime_error("LDAK LOCO " + path + ": expected second header token 'IID', got '" + tok + "'");
+
+    // Collect chromosome columns. chrCols[c] = "1".."22" if autosomal, else empty (skip).
+    std::vector<std::string> chrCols;
+    chrCols.reserve(32);
+    while (p < fend && *p != '\n' && *p != '\r') {
+        readToken(tok);
+        if (tok.empty()) break;
+        // Strip "Chr"/"chr" prefix.
+        std::string label = tok;
+        if (label.size() > 3 && (label[0] == 'C' || label[0] == 'c') && (label[1] == 'h' || label[1] == 'H') &&
+            (label[2] == 'r' || label[2] == 'R'))
+            label = label.substr(3);
+
+        // Autosomal check: integer 1–22.
+        bool autosomal = false;
+        if (!label.empty() && label.size() <= 2) {
+            int chrNum = 0;
+            bool ok = true;
+            for (char c : label) {
+                if (c < '0' || c > '9') { ok = false; break; }
+                chrNum = chrNum * 10 + (c - '0');
+            }
+            autosomal = ok && chrNum >= 1 && chrNum <= 22;
+        }
+        chrCols.push_back(autosomal ? label : std::string{});
+    }
+    if (p < fend && *p == '\r') ++p;
+    if (p < fend && *p == '\n') ++p;
+
+    if (chrCols.empty())
+        throw std::runtime_error("LDAK LOCO " + path + ": header has no chromosome columns");
+
+    // ── Pre-allocate output vectors for each kept chromosome ─────────
+    std::unordered_map<std::string, Eigen::VectorXd> result;
+    for (const auto &c : chrCols)
+        if (!c.empty()) result[c] = Eigen::VectorXd::Zero(nUsed);
+
+    // ── Build IID → usedIIDs index ──────────────────────────────────
+    std::unordered_map<std::string, Eigen::Index> iidIdx;
+    iidIdx.reserve(usedIIDs.size());
+    for (size_t i = 0; i < usedIIDs.size(); ++i)
+        iidIdx[usedIIDs[i]] = static_cast<Eigen::Index>(i);
+
+    std::vector<bool> usedHit(usedIIDs.size(), false);
+    std::string fidTok, iidTok;
+    fidTok.reserve(64);
+    iidTok.reserve(64);
+
+    const size_t nCols = chrCols.size();
+
+    // ── Data rows: FID  IID  v1 v2 ... vN ───────────────────────────
+    while (p < fend) {
+        while (p < fend && (*p == '\n' || *p == '\r')) ++p;
+        if (p >= fend) break;
+
+        readToken(fidTok);
+        if (fidTok.empty()) break;
+        readToken(iidTok);
+        if (iidTok.empty())
+            throw std::runtime_error("LDAK LOCO " + path + ": missing IID token after FID '" + fidTok + "'");
+
+        Eigen::Index pos = -1;
+        auto it = iidIdx.find(iidTok);
+        if (it != iidIdx.end()) pos = it->second;
+
+        for (size_t c = 0; c < nCols; ++c) {
+            skipWS();
+            char *ep;
+            double val = std::strtod(p, &ep);
+            if (ep == p)
+                throw std::runtime_error("LDAK LOCO " + path + " IID '" + iidTok +
+                                         "': invalid value at column " + std::to_string(c + 1));
+            p = ep;
+            if (pos >= 0 && !chrCols[c].empty())
+                result[chrCols[c]][pos] = val;
+        }
+        if (pos >= 0) usedHit[static_cast<size_t>(pos)] = true;
+
+        while (p < fend && *p != '\n') ++p;
+        if (p < fend) ++p;
+    }
+
+    for (size_t i = 0; i < usedIIDs.size(); ++i) {
+        if (!usedHit[i])
+            throw std::runtime_error("Subject '" + usedIIDs[i] + "' not found in LDAK LOCO file: " + path);
+    }
+
+    return result;
+}
+
 LocoData LocoData::load(
     const std::string &predListFile,
     const std::vector<std::string> &phenoNames,
@@ -221,7 +392,13 @@ LocoData LocoData::load(
     for (const auto &pn : phenoNames) {
         const std::string &locoPath = predMap.at(pn);
 
-        result.scores[pn] = parseLocoFile(locoPath, usedIIDs);
+        const LocoFormat fmt = detectLocoFormat(locoPath);
+        infoMsg("LOCO[%s]: detected %s format", pn.c_str(),
+                fmt == LocoFormat::Regenie ? "regenie" : "ldak");
+
+        result.scores[pn] = (fmt == LocoFormat::Regenie)
+            ? parseRegenieLocoFile(locoPath, usedIIDs)
+            : parseLdakLocoFile(locoPath, usedIIDs);
 
         if (result.scores[pn].size() < 22)
             throw std::runtime_error("LOCO file for '" + pn + "' contains " +

--- a/src/engine/loco.cpp
+++ b/src/engine/loco.cpp
@@ -24,6 +24,12 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
+
+// MAP_POPULATE is a Linux-specific flag that pre-faults pages on mmap.
+// macOS / BSD have no equivalent — fall back to plain MAP_PRIVATE.
+#ifndef MAP_POPULATE
+#  define MAP_POPULATE 0
+#endif
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/src/engine/marker.cpp
+++ b/src/engine/marker.cpp
@@ -625,12 +625,14 @@ void multiPhenoEngineRange(
             std::vector<std::vector<double> > winGSums;
             std::vector<double> passAltFreqs;
             std::vector<double> passGSums;
+            std::vector<double> passGSumSqs;
             std::vector<std::vector<double> > fusedResultsBuf;
 
             if (hasFused) {
                 winGSums.resize(nFuseable, std::vector<double>(B, 0.0));
                 passAltFreqs.reserve(B);
                 passGSums.reserve(B);
+                passGSumSqs.reserve(B);
             }
 
             // Pre-allocated passScores buffer (A2): reused across windows.
@@ -784,6 +786,7 @@ void multiPhenoEngineRange(
 
                             passAltFreqs.clear();
                             passGSums.clear();
+                            passGSumSqs.clear();
                             int passCount = 0;
 
                             for (size_t bi = 0; bi < wlen; ++bi) {
@@ -814,6 +817,7 @@ void multiPhenoEngineRange(
                                 if (wmQC[bi].pass) {
                                     passAltFreqs.push_back(gs.altFreq);
                                     passGSums.push_back(gSum);
+                                    passGSumSqs.push_back(gs.sumSq);
                                     ++passCount;
                                 }
                             }
@@ -838,7 +842,7 @@ void multiPhenoEngineRange(
 
                                     methods[p]->processScoreBatch(
                                         passScoresBuf.topLeftCorner(fp.nCols, passCount),
-                                        passGSums.data(), fp.nUsed,
+                                        passGSums.data(), passGSumSqs.data(), fp.nUsed,
                                         passAltFreqs, fusedResultsBuf);
                                 }
 

--- a/src/engine/marker.cpp
+++ b/src/engine/marker.cpp
@@ -625,14 +625,12 @@ void multiPhenoEngineRange(
             std::vector<std::vector<double> > winGSums;
             std::vector<double> passAltFreqs;
             std::vector<double> passGSums;
-            std::vector<double> passGSumSqs;
             std::vector<std::vector<double> > fusedResultsBuf;
 
             if (hasFused) {
                 winGSums.resize(nFuseable, std::vector<double>(B, 0.0));
                 passAltFreqs.reserve(B);
                 passGSums.reserve(B);
-                passGSumSqs.reserve(B);
             }
 
             // Pre-allocated passScores buffer (A2): reused across windows.
@@ -786,7 +784,6 @@ void multiPhenoEngineRange(
 
                             passAltFreqs.clear();
                             passGSums.clear();
-                            passGSumSqs.clear();
                             int passCount = 0;
 
                             for (size_t bi = 0; bi < wlen; ++bi) {
@@ -817,7 +814,6 @@ void multiPhenoEngineRange(
                                 if (wmQC[bi].pass) {
                                     passAltFreqs.push_back(gs.altFreq);
                                     passGSums.push_back(gSum);
-                                    passGSumSqs.push_back(gs.sumSq);
                                     ++passCount;
                                 }
                             }
@@ -842,7 +838,7 @@ void multiPhenoEngineRange(
 
                                     methods[p]->processScoreBatch(
                                         passScoresBuf.topLeftCorner(fp.nCols, passCount),
-                                        passGSums.data(), passGSumSqs.data(), fp.nUsed,
+                                        passGSums.data(), fp.nUsed,
                                         passAltFreqs, fusedResultsBuf);
                                 }
 

--- a/src/engine/marker.hpp
+++ b/src/engine/marker.hpp
@@ -111,18 +111,20 @@ class MethodBase {
 
     // Process pre-computed raw scores (from the fused GEMM).
     //   scores   — fusedGemmColumns() × B matrix of raw scores
-    //   gSums    — per-phenotype genotype sums, length B
+    //   gSums    — per-phenotype genotype sums, length B (post-impute Σ G)
+    //   gSumSqs  — per-phenotype Σ G², length B (post-impute, for empirical variance)
     //   nUsed    — this phenotype's sample count (for gMean = gSum / nUsed)
     //   altFreqs — ALT allele frequencies, length B (pre-computed)
     //   results  — output: results[b] = method-specific result values
     virtual void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) {
-        (void)scores; (void)gSums; (void)nUsed;
+        (void)scores; (void)gSums; (void)gSumSqs; (void)nUsed;
         (void)altFreqs; (void)results;
     }
 

--- a/src/engine/marker.hpp
+++ b/src/engine/marker.hpp
@@ -112,19 +112,17 @@ class MethodBase {
     // Process pre-computed raw scores (from the fused GEMM).
     //   scores   — fusedGemmColumns() × B matrix of raw scores
     //   gSums    — per-phenotype genotype sums, length B (post-impute Σ G)
-    //   gSumSqs  — per-phenotype Σ G², length B (post-impute, for empirical variance)
     //   nUsed    — this phenotype's sample count (for gMean = gSum / nUsed)
     //   altFreqs — ALT allele frequencies, length B (pre-computed)
     //   results  — output: results[b] = method-specific result values
     virtual void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
-        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) {
-        (void)scores; (void)gSums; (void)gSumSqs; (void)nUsed;
+        (void)scores; (void)gSums; (void)nUsed;
         (void)altFreqs; (void)results;
     }
 

--- a/src/engine/marker.hpp
+++ b/src/engine/marker.hpp
@@ -112,17 +112,19 @@ class MethodBase {
     // Process pre-computed raw scores (from the fused GEMM).
     //   scores   — fusedGemmColumns() × B matrix of raw scores
     //   gSums    — per-phenotype genotype sums, length B (post-impute Σ G)
+    //   gSumSqs  — per-phenotype genotype sum-of-squares, length B (post-impute Σ G²)
     //   nUsed    — this phenotype's sample count (for gMean = gSum / nUsed)
     //   altFreqs — ALT allele frequencies, length B (pre-computed)
     //   results  — output: results[b] = method-specific result values
     virtual void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) {
-        (void)scores; (void)gSums; (void)nUsed;
+        (void)scores; (void)gSums; (void)gSumSqs; (void)nUsed;
         (void)altFreqs; (void)results;
     }
 

--- a/src/engine/marker_impl.hpp
+++ b/src/engine/marker_impl.hpp
@@ -13,7 +13,9 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
-#include <immintrin.h>
+#if defined(__x86_64__) || defined(_M_X64)
+#  include <immintrin.h>
+#endif
 #include <string>
 #include <string_view>
 #include <vector>
@@ -185,7 +187,6 @@ static_assert(sizeof(PaddedFlag) == 64, "PaddedFlag must be 64 bytes");
 
 struct PhenoGenoStats {
     double altFreq, mac, missingRate, hweP;
-    double sumSq;   // post-imputation Σ G_i² over present subjects
 };
 
 // Compute per-phenotype genotype stats from union-level genotype vector
@@ -198,11 +199,9 @@ inline PhenoGenoStats statsFromUnionVec(
     uint32_t nUsed
 ) {
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0, nMissing = 0;
-    double sumSq = 0.0;
     for (uint32_t i = 0; i < nUnion; ++i) {
         if (mask[i] == 0.0) continue;  // absent from this phenotype
         const double v = unionG[i];
-        sumSq += v * v;                // post-impute Σv² (universal: hard-call/dosage/imputed)
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -213,7 +212,6 @@ inline PhenoGenoStats statsFromUnionVec(
             ++nMissing;  // NaN or dosage
     }
     PhenoGenoStats s;
-    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         // Dosage data: compute from gSum (not discrete genotypes).
@@ -242,14 +240,12 @@ inline PhenoGenoStats statsFromGVec(
 ) {
     indexForMissing.clear();
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0;
-    double sumSq = 0.0;
     for (uint32_t i = 0; i < n; ++i) {
         const double v = g[i];
         if (std::isnan(v) || v < 0.0) {
             indexForMissing.push_back(i);
             continue;
         }
-        sumSq += v * v;
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -260,7 +256,6 @@ inline PhenoGenoStats statsFromGVec(
             indexForMissing.push_back(i);
     }
     PhenoGenoStats s;
-    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         s.altFreq = NAN;
@@ -334,6 +329,7 @@ inline void extractGather(
         phenoG[j] = unionG[presentIndices[j]];
 }
 
+#if defined(__x86_64__) || defined(_M_X64)
 // AVX-512 compress-store extraction using precomputed bitmask.
 // presentMask is a packed bitmask: bit i set ↔ union subject i is present.
 // Processes 8 doubles per iteration using VCOMPRESSSTOREPD.
@@ -359,6 +355,7 @@ inline void extractCompress_avx512(
             phenoG[outIdx++] = unionG[i];
     }
 }
+#endif
 
 // Build bitmask from unionToLocal. Called once per MissBatch.
 inline std::vector<uint64_t> buildPresentMask(
@@ -387,11 +384,16 @@ inline void extractPhenoFast(
         std::memcpy(phenoG, unionG, static_cast<size_t>(nUsed) * sizeof(double));
         return;
     }
+#if defined(__x86_64__) || defined(_M_X64)
     if (simdLevel() >= SimdLevel::AVX512) {
         extractCompress_avx512(unionG, presentMask, nUnion, phenoG);
     } else {
         extractGather(unionG, presentIndices, nUsed, phenoG);
     }
+#else
+    (void)presentMask; (void)nUnion;
+    extractGather(unionG, presentIndices, nUsed, phenoG);
+#endif
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -454,7 +456,6 @@ inline void extractAndStatsBatched(
     for (size_t p = 0; p < K; ++p) {
         const uint32_t nonMissing = acc[p].nHomRef + acc[p].nHet + acc[p].nHomAlt;
         PhenoGenoStats &s = outStats[p];
-        s.sumSq = static_cast<double>(acc[p].nHet) + 4.0 * static_cast<double>(acc[p].nHomAlt);
         if (nonMissing == 0) {
             s.altFreq = NAN;
             s.mac = NAN;
@@ -520,7 +521,6 @@ inline PhenoGenoStats sparseExtractAndStats(
 
     // Compute stats from counts
     PhenoGenoStats s;
-    s.sumSq = static_cast<double>(counts[1]) + 4.0 * static_cast<double>(counts[2]);
     const uint32_t nonMissing = counts[0] + counts[1] + counts[2];
     if (nonMissing == 0) {
         s.altFreq = NAN;

--- a/src/engine/marker_impl.hpp
+++ b/src/engine/marker_impl.hpp
@@ -185,6 +185,7 @@ static_assert(sizeof(PaddedFlag) == 64, "PaddedFlag must be 64 bytes");
 
 struct PhenoGenoStats {
     double altFreq, mac, missingRate, hweP;
+    double sumSq;   // post-imputation Σ G_i² over present subjects
 };
 
 // Compute per-phenotype genotype stats from union-level genotype vector
@@ -197,9 +198,11 @@ inline PhenoGenoStats statsFromUnionVec(
     uint32_t nUsed
 ) {
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0, nMissing = 0;
+    double sumSq = 0.0;
     for (uint32_t i = 0; i < nUnion; ++i) {
         if (mask[i] == 0.0) continue;  // absent from this phenotype
         const double v = unionG[i];
+        sumSq += v * v;                // post-impute Σv² (universal: hard-call/dosage/imputed)
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -210,6 +213,7 @@ inline PhenoGenoStats statsFromUnionVec(
             ++nMissing;  // NaN or dosage
     }
     PhenoGenoStats s;
+    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         // Dosage data: compute from gSum (not discrete genotypes).
@@ -238,12 +242,14 @@ inline PhenoGenoStats statsFromGVec(
 ) {
     indexForMissing.clear();
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0;
+    double sumSq = 0.0;
     for (uint32_t i = 0; i < n; ++i) {
         const double v = g[i];
         if (std::isnan(v) || v < 0.0) {
             indexForMissing.push_back(i);
             continue;
         }
+        sumSq += v * v;
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -254,6 +260,7 @@ inline PhenoGenoStats statsFromGVec(
             indexForMissing.push_back(i);
     }
     PhenoGenoStats s;
+    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         s.altFreq = NAN;
@@ -447,6 +454,7 @@ inline void extractAndStatsBatched(
     for (size_t p = 0; p < K; ++p) {
         const uint32_t nonMissing = acc[p].nHomRef + acc[p].nHet + acc[p].nHomAlt;
         PhenoGenoStats &s = outStats[p];
+        s.sumSq = static_cast<double>(acc[p].nHet) + 4.0 * static_cast<double>(acc[p].nHomAlt);
         if (nonMissing == 0) {
             s.altFreq = NAN;
             s.mac = NAN;
@@ -512,6 +520,7 @@ inline PhenoGenoStats sparseExtractAndStats(
 
     // Compute stats from counts
     PhenoGenoStats s;
+    s.sumSq = static_cast<double>(counts[1]) + 4.0 * static_cast<double>(counts[2]);
     const uint32_t nonMissing = counts[0] + counts[1] + counts[2];
     if (nonMissing == 0) {
         s.altFreq = NAN;

--- a/src/engine/marker_impl.hpp
+++ b/src/engine/marker_impl.hpp
@@ -187,6 +187,9 @@ static_assert(sizeof(PaddedFlag) == 64, "PaddedFlag must be 64 bytes");
 
 struct PhenoGenoStats {
     double altFreq, mac, missingRate, hweP;
+    // Sum of squared post-impute genotypes over mask-included subjects.
+    // Used by SPAsqr to compute empirical Var(G) = (sumSq − sum²/n) / (n−1).
+    double sumSq;
 };
 
 // Compute per-phenotype genotype stats from union-level genotype vector
@@ -199,9 +202,11 @@ inline PhenoGenoStats statsFromUnionVec(
     uint32_t nUsed
 ) {
     uint32_t nHomRef = 0, nHet = 0, nHomAlt = 0, nMissing = 0;
+    double sumSq = 0.0;
     for (uint32_t i = 0; i < nUnion; ++i) {
         if (mask[i] == 0.0) continue;  // absent from this phenotype
         const double v = unionG[i];
+        sumSq += v * v;                // post-impute (caller has filled NaNs)
         if (v == 0.0)
             ++nHomRef;
         else if (v == 1.0)
@@ -209,9 +214,10 @@ inline PhenoGenoStats statsFromUnionVec(
         else if (v == 2.0)
             ++nHomAlt;
         else
-            ++nMissing;  // NaN or dosage
+            ++nMissing;  // imputed value or dosage
     }
     PhenoGenoStats s;
+    s.sumSq = sumSq;
     uint32_t nonMissing = nHomRef + nHet + nHomAlt;
     if (nonMissing == 0) {
         // Dosage data: compute from gSum (not discrete genotypes).

--- a/src/io/sparse_grm.cpp
+++ b/src/io/sparse_grm.cpp
@@ -5,7 +5,9 @@
 #include "util/text_scanner.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -95,13 +97,31 @@ std::vector<std::string> SparseGRM::readGctaIIDs(const std::string &spFile) {
     std::vector<std::string> iids;
     iids.reserve(65536);
     std::string line;
+    int iidCol = -1; // 0 = IID-only, 1 = FID+IID; auto-detected from first row
     while (std::getline(idStream, line)) {
         if (!line.empty() && line.back() == '\r') line.pop_back();
         if (line.empty()) continue;
+
         text::TokenScanner tok(line);
-        /*FID*/ tok.next();
-        std::string iid = tok.next();
-        if (iid.empty()) throw std::runtime_error(idFile + ": missing IID on line " + std::to_string(iids.size() + 1));
+        std::string tok1 = tok.next();
+        if (tok1.empty()) continue; // whitespace-only line
+        std::string tok2 = tok.next();
+
+        if (iidCol < 0) {
+            iidCol = tok2.empty() ? 0 : 1;
+            if (iidCol == 0)
+                infoMsg("%s: detected IID-only format (1 column)", idFile.c_str());
+            else
+                infoMsg("%s: detected FID+IID format; using IID column, ignoring FID", idFile.c_str());
+        } else if ((iidCol == 0 && !tok2.empty()) || (iidCol == 1 && tok2.empty())) {
+            throw std::runtime_error(idFile + ": inconsistent column count on line " +
+                                     std::to_string(iids.size() + 1) +
+                                     " (expected " + (iidCol == 0 ? "1" : "≥2") + " columns)");
+        }
+
+        std::string iid = (iidCol == 0) ? std::move(tok1) : std::move(tok2);
+        if (iid.empty())
+            throw std::runtime_error(idFile + ": missing IID on line " + std::to_string(iids.size() + 1));
         iids.push_back(std::move(iid));
     }
     return iids;
@@ -214,9 +234,17 @@ SparseGRM SparseGRM::fromGCTA(
 }
 
 void SparseGRM::buildDiagonal() {
-    m_diagonal.assign(m_nSubj, 0.0);
+    constexpr double kNoDiag = std::numeric_limits<double>::quiet_NaN();
+    m_diagonal.assign(m_nSubj, kNoDiag);
     for (const auto &e : m_entries) {
         if (e.row == e.col && e.row < m_nSubj) m_diagonal[e.row] = e.value;
+    }
+    uint32_t missing = 0;
+    for (double d : m_diagonal) if (std::isnan(d)) ++missing;
+    if (missing > 0) {
+        throw std::runtime_error("SparseGRM: " + std::to_string(missing) +
+                                 " of " + std::to_string(m_nSubj) +
+                                 " subjects have no diagonal entry");
     }
 }
 
@@ -284,6 +312,18 @@ SparseGRM SparseGRM::load(
     const std::vector<std::string> &subjectOrder,
     const std::vector<std::string> &famIIDs
 ) {
+    // No GRM provided → identity (diag = 1, no off-diag); assumes unrelated subjects.
+    if (grabFile.empty() && gctaFile.empty()) {
+        SparseGRM g;
+        g.m_nSubj = static_cast<uint32_t>(subjectOrder.size());
+        g.m_entries.reserve(g.m_nSubj);
+        for (uint32_t i = 0; i < g.m_nSubj; ++i)
+            g.m_entries.push_back({i, i, 1.0});
+        g.m_diagonal.assign(g.m_nSubj, 1.0);
+        infoMsg("Sparse GRM: no file provided, using identity GRM (diag=1.0, no off-diag) for %u subjects",
+                g.m_nSubj);
+        return g;
+    }
     if (!gctaFile.empty()) return fromGCTA(gctaFile, subjectOrder, famIIDs);
     return SparseGRM(grabFile, subjectOrder);
 }
@@ -309,6 +349,9 @@ std::unordered_set<std::string> SparseGRM::parseSubjectIDs(
     const std::vector<std::string> &famIIDs
 ) {
     std::unordered_set<std::string> ids;
+
+    // No GRM file: caller will use identity GRM downstream — no subject filtering.
+    if (grabFile.empty() && gctaFile.empty()) return ids;
 
     if (!gctaFile.empty()) {
         // ── GCTA format: read .grm.id ──────────────────────────────────

--- a/src/io/sparse_grm.hpp
+++ b/src/io/sparse_grm.hpp
@@ -96,7 +96,9 @@ class SparseGRM {
     }
 
     // Cached diagonal of G (self-relatedness per subject).
-    // diagonal()[i] == G(i,i).  Default 0.0 if subject has no diagonal entry.
+    // diagonal()[i] == G(i,i).  Loader throws if any subject has no
+    // diagonal entry — every subject in subjectOrder must have an
+    // explicit (i, i, value) row in the input file.
     const std::vector<double> &diagonal() const {
         return m_diagonal;
     }

--- a/src/localplus/abed_io.cpp
+++ b/src/localplus/abed_io.cpp
@@ -9,7 +9,9 @@ extern "C" {
 #include <htslib/bgzf.h>
 }
 
-#include <immintrin.h>
+#if defined(__x86_64__) || defined(_M_X64)
+#  include <immintrin.h>
+#endif
 #include "util/simd_dispatch.hpp"
 
 #include <algorithm>
@@ -272,6 +274,7 @@ const uint8_t *AdmixCursor::readTrackPtr(
     return m_rawBytes.data();
 }
 
+#if defined(__x86_64__) || defined(_M_X64)
 // ── AVX2 helper for no-missing 2-bit decode ─────────────────────────
 // Returns number of full bytes decoded (caller handles the scalar tail).
 __attribute__((target("avx2")))
@@ -295,6 +298,7 @@ static uint32_t decodeNoMissAVX2(
     }
     return b;
 }
+#endif
 
 void AdmixCursor::decodeTrack(
     const uint8_t *raw,
@@ -317,10 +321,12 @@ void AdmixCursor::decodeTrack(
             uint32_t di = 0;
             uint32_t b = 0;
 
+#if defined(__x86_64__) || defined(_M_X64)
             if (simdLevel() >= SimdLevel::AVX2) {
                 b = decodeNoMissAVX2(raw, p, fullBytes);
                 di = b * 4;
             }
+#endif
 
             // Scalar tail
             for (; b < fullBytes; ++b) {
@@ -471,6 +477,7 @@ void AbedWriter::writeTrack(
     if (bgzf_write(m_bgzf, data, nBytes) < 0) throw std::runtime_error("Failed to write ABED track");
 }
 
+#if defined(__x86_64__) || defined(_M_X64)
 // ── AVX2 helper for PLINK encode (32 int8 samples → 8 packed bytes) ─────────
 __attribute__((target("avx2")))
 static uint64_t encodeSamplesAVX2(
@@ -509,6 +516,7 @@ static uint64_t encodeSamplesAVX2(
     }
     return i;
 }
+#endif
 
 std::vector<uint8_t> AbedWriter::encode(const std::vector<int8_t> &values) {
     // PLINK encoding: 0→0b00, 1→0b10, 2→0b11, -1(missing)→0b01
@@ -518,8 +526,10 @@ std::vector<uint8_t> AbedWriter::encode(const std::vector<int8_t> &values) {
 
     uint64_t i = 0;
 
+#if defined(__x86_64__) || defined(_M_X64)
     if (simdLevel() >= SimdLevel::AVX2)
         i = encodeSamplesAVX2(values.data(), packed.data(), n);
+#endif
 
     // ── Scalar tail ───────────────────────────────────────────────
     for (; i < n; ++i) {

--- a/src/localplus/spamixlocalp.cpp
+++ b/src/localplus/spamixlocalp.cpp
@@ -66,12 +66,16 @@ RprodSoA buildRprodSoA(
 // __builtin_cpu_supports() and caches the result; callers pay only a
 // predictable branch per invocation.
 
-#include <immintrin.h>
+#if defined(__x86_64__) || defined(_M_X64)
+#  include <immintrin.h>
+#endif
 #include "util/simd_dispatch.hpp"
 
 // ════════════════════════════════════════════════════════════════════════
 // computeVarOffSoA — single-marker off-diagonal variance
 // ════════════════════════════════════════════════════════════════════════
+
+#if defined(__x86_64__) || defined(_M_X64)
 
 // ── AVX-512: 8 phi entries per iteration ────────────────────────────
 
@@ -180,6 +184,8 @@ static double computeVarOffSoA_avx2(
     return varOff;
 }
 
+#endif  // x86_64 SIMD variants — single-marker
+
 // ── Scalar baseline ─────────────────────────────────────────────────
 
 static double computeVarOffSoA_scalar(
@@ -200,11 +206,14 @@ double computeVarOffSoA(
     const uint32_t *hInt,
     uint32_t                                                               /*nUsed*/
 ) {
+#if defined(__x86_64__) || defined(_M_X64)
     switch (simdLevel()) {
     case SimdLevel::AVX512: return computeVarOffSoA_avx512(rp, hInt);
     case SimdLevel::AVX2:   return computeVarOffSoA_avx2(rp, hInt);
-    default:                return computeVarOffSoA_scalar(rp, hInt);
+    default: break;
     }
+#endif
+    return computeVarOffSoA_scalar(rp, hInt);
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -213,6 +222,8 @@ double computeVarOffSoA(
 // Each phi entry reads PHI_BATCH consecutive uint32s (1–2 cache lines),
 // amortising DRAM bandwidth across all batch markers.
 // ════════════════════════════════════════════════════════════════════════
+
+#if defined(__x86_64__) || defined(_M_X64)
 
 // ── AVX-512: one __m512d accumulator covers all 8 batch items ───────
 
@@ -317,6 +328,8 @@ static void computeVarOffSoABatch_avx2(
         varOff[b] = tmp[b];
 }
 
+#endif  // x86_64 SIMD variants — batch
+
 // ── Scalar baseline ─────────────────────────────────────────────────
 
 static void computeVarOffSoABatch_scalar(
@@ -347,11 +360,14 @@ void computeVarOffSoABatch(
     int batchLen,
     double *varOff
 ) {
+#if defined(__x86_64__) || defined(_M_X64)
     switch (simdLevel()) {
-    case SimdLevel::AVX512: computeVarOffSoABatch_avx512(rp, hIntSM, batchLen, varOff); break;
-    case SimdLevel::AVX2:   computeVarOffSoABatch_avx2(rp, hIntSM, batchLen, varOff); break;
-    default:                computeVarOffSoABatch_scalar(rp, hIntSM, batchLen, varOff); break;
+    case SimdLevel::AVX512: computeVarOffSoABatch_avx512(rp, hIntSM, batchLen, varOff); return;
+    case SimdLevel::AVX2:   computeVarOffSoABatch_avx2(rp, hIntSM, batchLen, varOff); return;
+    default: break;
     }
+#endif
+    computeVarOffSoABatch_scalar(rp, hIntSM, batchLen, varOff);
 }
 
 // ======================================================================

--- a/src/spagrm/ibd.cpp
+++ b/src/spagrm/ibd.cpp
@@ -34,10 +34,14 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <immintrin.h>
+#if defined(__x86_64__) || defined(_M_X64)
+#  include <immintrin.h>
+#endif
 #include "util/simd_dispatch.hpp"
 
 // ── IBD pair accumulation — multi-versioned SIMD kernels ─────────────
+
+#if defined(__x86_64__) || defined(_M_X64)
 
 __attribute__((target("avx2,avx512f,avx512vl,fma")))
 static void ibdAccPairs_avx512(
@@ -131,6 +135,8 @@ static void ibdAccPairs_avx2(
     }
 }
 
+#endif  // x86_64 SIMD variants
+
 static void ibdAccPairs_scalar(
     const double *genoPtr,
     const int32_t *i1,
@@ -153,11 +159,14 @@ using IbdAccFn = void (*)(const double *, const int32_t *, const int32_t *,
                           double *, double *, double, double, size_t);
 
 static IbdAccFn pickIbdAccFn() {
+#if defined(__x86_64__) || defined(_M_X64)
     switch (simdLevel()) {
     case SimdLevel::AVX512: return ibdAccPairs_avx512;
     case SimdLevel::AVX2:   return ibdAccPairs_avx2;
-    default:                return ibdAccPairs_scalar;
+    default: break;
     }
+#endif
+    return ibdAccPairs_scalar;
 }
 
 static const IbdAccFn ibdAccPairs = pickIbdAccFn();

--- a/src/spagrm/spagrm.hpp
+++ b/src/spagrm/spagrm.hpp
@@ -302,10 +302,12 @@ class SPAGRMMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) override {
+        (void)gSumSqs;
         const int B = static_cast<int>(scores.cols());
         results.resize(B);
         const double residSum = m_spagrm.residSum();

--- a/src/spagrm/spagrm.hpp
+++ b/src/spagrm/spagrm.hpp
@@ -302,10 +302,12 @@ class SPAGRMMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) override {
+        (void)gSumSqs;   // SPAGRM uses theoretical 2p(1-p); empirical Σv² unused
         const int B = static_cast<int>(scores.cols());
         results.resize(B);
         const double residSum = m_spagrm.residSum();

--- a/src/spagrm/spagrm.hpp
+++ b/src/spagrm/spagrm.hpp
@@ -302,12 +302,10 @@ class SPAGRMMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
-        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
     ) override {
-        (void)gSumSqs;   // SPAGRM uses theoretical 2p(1-p); empirical Σv² unused
         const int B = static_cast<int>(scores.cols());
         results.resize(B);
         const double residSum = m_spagrm.residSum();

--- a/src/spasqr/conquer.cpp
+++ b/src/spasqr/conquer.cpp
@@ -129,7 +129,9 @@ Eigen::VectorXd huberReg(
     double tol,
     double constTau,
     int iteMax,
-    double stepMax
+    double stepMax,
+    int *iterOut = nullptr,
+    double *finalGradNormOut = nullptr
 ) {
     double rob = constTau * eigMad(Y);
     updateHuber(Z, Y, tau, der, gradOld, n, rob, n1);
@@ -157,6 +159,8 @@ Eigen::VectorXd huberReg(
         gradDiff = gradNew - gradOld;
         ++ite;
     }
+    if (iterOut) *iterOut = ite;
+    if (finalGradNormOut) *finalGradNormOut = gradNew.lpNorm<Eigen::Infinity>();
     return beta;
 }
 
@@ -174,7 +178,8 @@ Eigen::VectorXd smqrGauss(
     Eigen::VectorXd *residOut,
     double tol,
     int iteMax,
-    double stepMax
+    double stepMax,
+    ConquerStatus *statusOut
 ) {
     const int n = static_cast<int>(X.rows());
     const int p = static_cast<int>(X.cols());
@@ -206,7 +211,10 @@ Eigen::VectorXd smqrGauss(
     Eigen::VectorXd der(n), gradOld(p + 1), gradNew(p + 1);
 
     // Phase 1: Huber initialization
-    Eigen::VectorXd beta = huberReg(Z, Yc, tau, der, gradOld, gradNew, n, p, n1, tol, constTau, iteMax, stepMax);
+    int huberIter = 0;
+    double huberFinalGradNorm = 0.0;
+    Eigen::VectorXd beta = huberReg(Z, Yc, tau, der, gradOld, gradNew, n, p, n1, tol, constTau, iteMax, stepMax,
+                                    &huberIter, &huberFinalGradNorm);
 
     // Quantile intercept adjustment
     Eigen::VectorXd resNoIntercept = Yc - Z.rightCols(p) * beta.tail(p);
@@ -239,11 +247,23 @@ Eigen::VectorXd smqrGauss(
         ++ite;
     }
 
+    const double gaussFinalGradNorm = gradNew.lpNorm<Eigen::Infinity>();
+
     // Un-standardize coefficients
     beta.tail(p).array() *= sx.array();
     beta(0) += my - (mx.array() * beta.tail(p).transpose().array()).sum();
 
     if (residOut) *residOut = res;
+
+    if (statusOut) {
+        statusOut->huberIter = huberIter;
+        statusOut->huberConverged = (huberFinalGradNorm <= tol) && (huberIter <= iteMax);
+        statusOut->huberFinalGradNorm = huberFinalGradNorm;
+        statusOut->gaussIter = ite;
+        statusOut->gaussConverged = (gaussFinalGradNorm <= tol) && (ite <= iteMax);
+        statusOut->gaussFinalGradNorm = gaussFinalGradNorm;
+        statusOut->converged = statusOut->huberConverged && statusOut->gaussConverged;
+    }
 
     return beta;
 }

--- a/src/spasqr/conquer.hpp
+++ b/src/spasqr/conquer.hpp
@@ -15,6 +15,21 @@
 
 namespace conquer {
 
+// Per-fit convergence diagnostics for smqrGauss.
+//
+// `converged` is true iff BOTH the Huber init phase and the Gaussian
+// smoothed phase reached the gradient tolerance within their iteration
+// budgets.  The per-phase fields let callers diagnose which phase failed.
+struct ConquerStatus {
+    bool   converged          = false; // both phases met tol
+    int    huberIter          = 0;     // iterations used in Phase 1 (Huber init)
+    bool   huberConverged     = false;
+    double huberFinalGradNorm = 0.0;   // final ||grad||_∞ of Phase 1
+    int    gaussIter          = 0;     // iterations used in Phase 2 (Gaussian smoothed)
+    bool   gaussConverged     = false;
+    double gaussFinalGradNorm = 0.0;   // final ||grad||_∞ of Phase 2
+};
+
 // Run smoothed quantile regression for a single tau.
 //
 //   X  : n × p  design matrix (raw covariates, NOT including intercept)
@@ -24,6 +39,10 @@ namespace conquer {
 //
 // Returns (p+1) coefficient vector:  beta(0) = intercept,  beta(1..p) = slopes.
 // Also stores the final n-vector of residuals in `residOut` if non-null.
+//
+// If `statusOut` is non-null, populates it with per-phase convergence info.
+// The function never throws on non-convergence — callers must check
+// `statusOut->converged` and decide how to react.
 Eigen::VectorXd smqrGauss(
     const Eigen::MatrixXd &X,
     const Eigen::VectorXd &Y,
@@ -32,7 +51,8 @@ Eigen::VectorXd smqrGauss(
     Eigen::VectorXd *residOut = nullptr,
     double tol = 1e-7,
     int iteMax = 5000,
-    double stepMax = 100.0
+    double stepMax = 100.0,
+    ConquerStatus *statusOut = nullptr
 );
 
 } // namespace conquer

--- a/src/spasqr/spasqr.cpp
+++ b/src/spasqr/spasqr.cpp
@@ -370,15 +370,17 @@ struct SPAsqrSPAShared {
 };
 
 // ── Per-tau p-value (replaces SPAGRMClass::getMarkerPvalFromScore) ──
+// G_var = empirical Var(G) from the caller (post-imputation, per-pheno).
+// MAF kept for SPA CGF (binomial structural assumption); not used for variance.
 inline double scalarGetPvalFromScore(
     double Score,
     double altFreq,
+    double G_var,
     double &zScore,
     const SPAsqrPerTau &tau,
     const SPAsqrSPAShared &spa
 ) {
     const double MAF       = std::min(altFreq, 1.0 - altFreq);
-    const double G_var     = 2.0 * MAF * (1.0 - MAF);
     const double Score_var = G_var * tau.R_GRM_R;
 
     if (Score_var <= 0.0 || MAF <= 0.0) {
@@ -417,14 +419,16 @@ inline double scalarGetPvalFromScore(
 // Computes the SPA p-value for a marker that failed the normal-approx
 // cutoff.  Both tails share the MAF/variance setup and outlier data
 // pointer extraction; only the Newton root and saddlepoint differ.
+// G_var = empirical Var(G) from caller; ratio EmpVar/Score_var is invariant
+// to the choice of variance, so SPA tails behave the same as before.
 inline double fusedGetPvalSpa(
     double Score,
     double altFreq,
+    double G_var,
     const SPAsqrPerTau &tau,
     const SPAsqrSPAShared &spa
 ) {
     const double MAF       = std::min(altFreq, 1.0 - altFreq);
-    const double G_var     = 2.0 * MAF * (1.0 - MAF);
     const double Score_var = G_var * tau.R_GRM_R;
 
     const double EmpVar    = G_var * (tau.R_GRM_R_nonOutlier + tau.sum_unrelated_outliers2);
@@ -532,12 +536,17 @@ class SPAsqrMethod : public MethodBase {
         result.clear();
         result.reserve(2 * m_ntaus + 1);
 
-        const double gMean = GVec.mean();
+        const double n      = static_cast<double>(GVec.size());
+        const double gSum   = GVec.sum();
+        const double gSumSq = GVec.squaredNorm();
+        const double gMean  = gSum / n;
+        const double G_var  = (gSumSq - gSum * gSum / n) / (n - 1.0);
+
         Eigen::VectorXd scores = m_methodShared->residMat.transpose() * GVec;
         for (int i = 0; i < m_ntaus; ++i)
             scores[i] -= gMean * m_methodShared->residSums[i];
 
-        processOneMarker(scores.data(), altFreq, result);
+        processOneMarker(scores.data(), altFreq, G_var, result);
     }
 
     // ── Batched analysis: B markers at once ────────────────────────────
@@ -555,8 +564,14 @@ class SPAsqrMethod : public MethodBase {
         const Eigen::VectorXd gMeans = GBatch.colwise().mean();
         scoreMatrix.noalias() -= m_methodShared->residSums * gMeans.transpose();
 
-        for (int b = 0; b < B; ++b)
-            processOneMarker(scoreMatrix.col(b).data(), altFreqs[b], results[b]);
+        const double n  = static_cast<double>(GBatch.rows());
+        const double n1 = n - 1.0;
+        for (int b = 0; b < B; ++b) {
+            const double gSum   = GBatch.col(b).sum();
+            const double gSumSq = GBatch.col(b).squaredNorm();
+            const double G_var  = (gSumSq - gSum * gSum / n) / n1;
+            processOneMarker(scoreMatrix.col(b).data(), altFreqs[b], G_var, results[b]);
+        }
     }
 
     int preferredBatchSize() const override {
@@ -593,6 +608,7 @@ class SPAsqrMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
@@ -602,7 +618,9 @@ class SPAsqrMethod : public MethodBase {
 
         // ── Center scores ──────────────────────────────────────────
         m_centeredBuf = scores;
-        const double invN = 1.0 / static_cast<double>(nUsed);
+        const double n    = static_cast<double>(nUsed);
+        const double n1   = n - 1.0;
+        const double invN = 1.0 / n;
         for (int b = 0; b < B; ++b) {
             const double gMean = gSums[b] * invN;
             for (int t = 0; t < m_ntaus; ++t)
@@ -624,7 +642,11 @@ class SPAsqrMethod : public MethodBase {
                 const double Score   = m_centeredBuf(t, b);
                 const double altFreq = altFreqs[b];
                 const double MAF     = std::min(altFreq, 1.0 - altFreq);
-                const double G_var   = 2.0 * MAF * (1.0 - MAF);
+                // Empirical Var(G) on the post-imputation, per-pheno column.
+                // gSums / gSumSqs come from the engine after Phase-1b imputation.
+                const double gSum    = gSums[b];
+                const double gSumSq  = gSumSqs[b];
+                const double G_var   = (gSumSq - gSum * gSum * invN) / n1;
                 const double Svar    = G_var * tau.R_GRM_R;
 
                 double z, p;
@@ -640,7 +662,7 @@ class SPAsqrMethod : public MethodBase {
                         p = 2.0 * math::pnorm(std::abs(z), 0.0, 1.0, false);
                     } else {
                         // Slow path: C3 fused upper+lower SPA
-                        p = fusedGetPvalSpa(Score, altFreq, tau, *m_spaShared);
+                        p = fusedGetPvalSpa(Score, altFreq, G_var, tau, *m_spaShared);
                     }
                 }
                 zBuf[b * m_ntaus + t] = z;
@@ -708,6 +730,7 @@ class SPAsqrMethod : public MethodBase {
     void processOneMarker(
         const double *centeredScores,
         double altFreq,
+        double G_var,
         std::vector<double> &result
     ) {
         result.clear();
@@ -719,7 +742,7 @@ class SPAsqrMethod : public MethodBase {
 
         for (int i = 0; i < m_ntaus; ++i) {
             double z;
-            double p = scalarGetPvalFromScore(centeredScores[i], altFreq, z,
+            double p = scalarGetPvalFromScore(centeredScores[i], altFreq, G_var, z,
                                               m_spaShared->perTau[i], *m_spaShared);
             zScores[i] = z;
             pvals[i] = p;
@@ -1108,8 +1131,18 @@ void runSPAsqr(
 
             try {
                 Eigen::VectorXd resid;
-                Eigen::VectorXd beta = conquer::smqrGauss(pw[k].X, pw[k].Y, taus[t], pw[k].h, &resid, spasqrTol);
+                conquer::ConquerStatus st;
+                Eigen::VectorXd beta = conquer::smqrGauss(pw[k].X, pw[k].Y, taus[t], pw[k].h, &resid, spasqrTol,
+                                                          5000, 100.0, &st);
                 infoMsg("[%s] tau=%.4f intercept=%.6f", phenoNames[k].c_str(), taus[t], beta(0));
+                if (!st.converged) {
+                    warnMsg("[%s] tau=%.4f conquer did not converge: huber=%d iters (||g||=%.3e, %s),"
+                            " gauss=%d iters (||g||=%.3e, %s); tol=%.3e",
+                            phenoNames[k].c_str(), taus[t],
+                            st.huberIter, st.huberFinalGradNorm, st.huberConverged ? "ok" : "FAIL",
+                            st.gaussIter, st.gaussFinalGradNorm, st.gaussConverged ? "ok" : "FAIL",
+                            spasqrTol);
+                }
 
                 const Eigen::Index Nk = static_cast<Eigen::Index>(pw[k].nk);
                 for (Eigen::Index i = 0; i < Nk; ++i)
@@ -1221,11 +1254,16 @@ void runSPAsqr(
 // ══════════════════════════════════════════════════════════════════════
 // runSPAsqrLoco — LOCO entry point
 //
-// Matches the serial workflow (2.serial_loco.sh):
-//   - conquer fits are chromosome-independent (same Y, same X)
-//   - per-phenotype bandwidth h
-//   - SPAsqrMethod built once per phenotype, cloned per chromosome
-//   - locoEngine iterates chromosomes, testing each chromosome's markers
+// Per-chromosome workflow:
+//   - For each chromosome, the buildTasks callback rebuilds the conquer fits
+//     based on that chromosome's LOCO PRS column.
+//   - Both modes feed conquer with X = pw[k].baseX (original covariates only,
+//     no LOCO augmentation) and y_adj computed per chromosome:
+//       offset    → y_adj = IRN(y_raw) - loco_chr     (β=1, α=0; IRN once before loop)
+//       covariate → y_adj = y_raw - α̂ - β̂·loco_chr   (per-chr OLS partial-out, raw y)
+//   - Per-chr bandwidth h_chr[k] = IQR(y_adj) / scale in BOTH modes (chr-specific).
+//   - locoEngine iterates chromosomes, testing each chromosome's markers via
+//     the multi-phenotype work-stealing engine.
 // ══════════════════════════════════════════════════════════════════════
 
 void runSPAsqrLoco(
@@ -1254,7 +1292,8 @@ void runSPAsqrLoco(
     double spasqrH,
     double spasqrHScale,
     const std::string &keepFile,
-    const std::string &removeFile
+    const std::string &removeFile,
+    const std::string &locoMode
 ) {
     const int K = static_cast<int>(phenoNames.size());
     const int ntaus = static_cast<int>(taus.size());
@@ -1263,6 +1302,7 @@ void runSPAsqrLoco(
     // Union = subjects with genotype ∩ GRM ∩ keep/remove.  Per-phenotype
     // NA filtering is deferred — each phenotype uses its own non-missing
     // subset of the union.
+    infoMsg("SPAsqr-LOCO mode: %s", locoMode.c_str());
     infoMsg("SPAsqr-LOCO: Loading phenotype and covariate data (%d phenotypes, %d taus)", K, ntaus);
     auto famIIDs = parseGenoIIDs(geno);
     SubjectData sd(std::move(famIIDs));
@@ -1317,6 +1357,14 @@ void runSPAsqrLoco(
             if (nCov > 0) pw[k].baseX.row(li) = unionX.row(i);
         }
 
+        // In offset mode, replace Y with its inverse-rank-normal
+        // transform (per-phenotype non-missing scope, Blom plotting position,
+        // average-rank ties).  All downstream math (bandwidth, conquer fit,
+        // y_adj per chromosome) operates on the IRN'd Y.
+        if (locoMode == "offset") {
+            pw[k].Y = math::inverseRankNormal(pw[k].Y);
+        }
+
         // Per-phenotype bandwidth
         if (spasqrH >= 0.0) {
             pw[k].h = spasqrH;
@@ -1340,17 +1388,23 @@ void runSPAsqrLoco(
     }
 
     // Log N/bandwidth table
+    // Both modes compute per-chr h_chr = IQR(y_adj)/scale inside the chr loop;
+    // the value shown here is the GLOBAL reference h derived from IQR(pw[k].Y)
+    // (= IQR(Y_irn) in offset, IQR(Y_raw) in covariate). Actual per-chr h is
+    // logged via "SPAsqr-LOCO chr%s [...]: per-chr h = ...".
     {
+        const char *bwLabel = "global_h(ref)";
         infoMsg("Sample size and smooth bandwidth per phenotype:");
         size_t nameW = 4;
         for (int k = 0; k < K; ++k)
             nameW = std::max(nameW, phenoNames[k].size());
         nameW += 2;
         char row[256];
-        std::snprintf(row, sizeof(row), "    %-*s %10s %12s\n", static_cast<int>(nameW), "", "N", "bandwidth");
+        std::snprintf(row, sizeof(row), "    %-*s %10s %14s\n",
+                      static_cast<int>(nameW), "", "N", bwLabel);
         fprintf(stderr, "%s", row);
         for (int k = 0; k < K; ++k) {
-            std::snprintf(row, sizeof(row), "    %-*s %10u %12.6f\n",
+            std::snprintf(row, sizeof(row), "    %-*s %10u %14.6f\n",
                           static_cast<int>(nameW), phenoNames[k].c_str(), pw[k].nk, pw[k].h);
             fprintf(stderr, "%s", row);
         }
@@ -1381,25 +1435,93 @@ void runSPAsqrLoco(
         phenoGrms[k] = reindexGrm(unionGrm, pw[k].unionToLocal, nUnion);
 
     // ── 7. Build LocoTaskBuilder callback ──────────────────────────
-    // For each chromosome, augment base covariates with the LOCO column
-    // (mapped to pheno-dense space), run K × ntaus conquer fits, and
-    // build K SPAsqrMethods.
+    // For each chromosome, build per-pheno y_adj (mode-dependent), run
+    // K × ntaus conquer fits with X = baseX, and build K SPAsqrMethods.
     auto buildTasks = [&](const std::string &chr, std::vector<PhenoTask> &tasks) {
         tasks.resize(K);
 
-        // Augment base covariates with LOCO column per phenotype (pheno-dense)
-        std::vector<Eigen::MatrixXd> X_augs(K);
+        // Both modes feed conquer with X = pw[k].baseX. Only y_adj differs:
+        //   offset    → y_adj = pw[k].Y(IRN'd) - loco_chr_pheno_dense        (β=1, α=0)
+        //   covariate → y_adj = pw[k].Y(raw)   - α̂ - β̂·loco_chr_pheno_dense  (per-chr OLS)
+        // Per-chr bandwidth h_chr[k] = IQR(y_adj) / scale in both modes.
+        std::vector<Eigen::VectorXd> y_adjs(K);
+        std::vector<double> h_chr(K, 0.0);
+
         for (int k = 0; k < K; ++k) {
             const Eigen::Index Nk = static_cast<Eigen::Index>(pw[k].nk);
-            X_augs[k].resize(Nk, nCov + 1);
-            X_augs[k].leftCols(nCov) = pw[k].baseX;
-            // Extract LOCO scores from union to pheno-dense space
+
+            // Map LOCO scores from union → pheno-dense (Nk-length) space.
             const auto &locoVec = loco.scores.at(phenoNames[k]).at(chr);
+            Eigen::VectorXd loco_dense(Nk);
             for (uint32_t i = 0; i < nUnion; ++i) {
                 uint32_t li = pw[k].unionToLocal[i];
                 if (li != UINT32_MAX)
-                    X_augs[k](li, nCov) = locoVec[i];
+                    loco_dense[li] = locoVec[i];
             }
+
+            // Compute y_adj per mode.
+            if (locoMode == "offset") {
+                // Raw subtraction of loco from IRN'd Y (pw[k].Y already IRN'd in §3).
+                y_adjs[k] = pw[k].Y - loco_dense;
+            } else { // covariate
+                // OLS y_raw ~ 1 + loco_dense  (pw[k].Y stays raw — IRN is offset-only).
+                const double y_mean = pw[k].Y.mean();
+                const double l_mean = loco_dense.mean();
+                const Eigen::ArrayXd y_dev = pw[k].Y.array() - y_mean;
+                const Eigen::ArrayXd l_dev = loco_dense.array() - l_mean;
+                const double l_var = l_dev.square().sum();
+                double beta_hat  = 0.0;
+                double alpha_hat = y_mean;
+                if (l_var > 0.0) {
+                    beta_hat  = (y_dev * l_dev).sum() / l_var;
+                    alpha_hat = y_mean - beta_hat * l_mean;
+                }
+                y_adjs[k] = pw[k].Y.array() - alpha_hat - beta_hat * loco_dense.array();
+                infoMsg("SPAsqr-LOCO chr%s [%s] covariate: OLS partial-out alpha=%.6f beta=%.6f",
+                        chr.c_str(), phenoNames[k].c_str(), alpha_hat, beta_hat);
+            }
+
+            // Diagnostic: corr(Y, loco_chr)^2 in pheno-dense space.
+            // Y here = pw[k].Y (IRN'd in offset mode, raw in covariate mode).
+            double r2_loco = 0.0;
+            {
+                const double mean_y = pw[k].Y.mean();
+                const double mean_l = loco_dense.mean();
+                const Eigen::ArrayXd dev_y = pw[k].Y.array() - mean_y;
+                const Eigen::ArrayXd dev_l = loco_dense.array() - mean_l;
+                const double cov_yl  = (dev_y * dev_l).sum();
+                const double var_y   = dev_y.square().sum();
+                const double var_l   = dev_l.square().sum();
+                if (var_y > 0.0 && var_l > 0.0)
+                    r2_loco = (cov_yl * cov_yl) / (var_y * var_l);
+            }
+
+            // Per-chromosome bandwidth from IQR(y_adj).  --spasqr-h overrides auto-IQR.
+            if (spasqrH >= 0.0) {
+                h_chr[k] = spasqrH;
+            } else {
+                std::vector<double> ysorted(static_cast<size_t>(Nk));
+                Eigen::VectorXd::Map(ysorted.data(), Nk) = y_adjs[k];
+                std::sort(ysorted.begin(), ysorted.end());
+                auto quant = [&](double prob) -> double {
+                    double idx = prob * (Nk - 1);
+                    Eigen::Index lo = static_cast<Eigen::Index>(std::floor(idx));
+                    Eigen::Index hi = std::min(lo + 1, Nk - 1);
+                    double frac = idx - lo;
+                    return ysorted[lo] * (1.0 - frac) + ysorted[hi] * frac;
+                };
+                double iqr = quant(0.75) - quant(0.25);
+                double scale = (spasqrHScale >= 0.0) ? spasqrHScale : 3.0;
+                h_chr[k] = iqr / scale;
+                if (h_chr[k] <= 0.0)
+                    h_chr[k] = std::max(std::pow((std::log(Nk) + nCov) / static_cast<double>(Nk), 0.4), 0.05);
+            }
+
+            const char *yLabel = (locoMode == "offset") ? "Y_irn" : "Y_raw";
+            infoMsg("SPAsqr-LOCO chr%s [%s][%s]: per-chr h = IQR(y_adj)/scale = %.6f (Nk=%u),"
+                    " corr(%s, loco)^2 = %.4f",
+                    chr.c_str(), phenoNames[k].c_str(), locoMode.c_str(),
+                    h_chr[k], pw[k].nk, yLabel, r2_loco);
         }
 
         // Parallel conquer fits: K × ntaus
@@ -1421,11 +1543,25 @@ void runSPAsqrLoco(
                 if (idx >= totalFits) break;
                 int k = idx / ntaus;
                 int t = idx % ntaus;
-                const double h1 = 1.0 / pw[k].h;
+                const double h_use = h_chr[k];
+                const double h1    = 1.0 / h_use;
 
                 try {
                     Eigen::VectorXd resid;
-                    conquer::smqrGauss(X_augs[k], pw[k].Y, taus[t], pw[k].h, &resid, spasqrTol);
+                    conquer::ConquerStatus st;
+                    // Both modes: SQR on (baseX, y_adjs[k]).
+                    //   offset    → y_adjs[k] = IRN(y) - loco_chr
+                    //   covariate → y_adjs[k] = y_raw - α̂ - β̂·loco_chr   (per-chr OLS partial-out)
+                    conquer::smqrGauss(pw[k].baseX, y_adjs[k], taus[t], h_use, &resid, spasqrTol,
+                                       5000, 100.0, &st);
+                    if (!st.converged) {
+                        warnMsg("[%s] chr%s tau=%.4f conquer did not converge: huber=%d iters (||g||=%.3e, %s),"
+                                " gauss=%d iters (||g||=%.3e, %s); tol=%.3e",
+                                phenoNames[k].c_str(), chr.c_str(), taus[t],
+                                st.huberIter, st.huberFinalGradNorm, st.huberConverged ? "ok" : "FAIL",
+                                st.gaussIter, st.gaussFinalGradNorm, st.gaussConverged ? "ok" : "FAIL",
+                                spasqrTol);
+                    }
 
                     const Eigen::Index Nk = static_cast<Eigen::Index>(pw[k].nk);
                     for (Eigen::Index i = 0; i < Nk; ++i)

--- a/src/spasqr/spasqr.cpp
+++ b/src/spasqr/spasqr.cpp
@@ -379,7 +379,7 @@ struct SPAsqrSPAShared {
 };
 
 // ── Per-tau p-value (replaces SPAGRMClass::getMarkerPvalFromScore) ──
-// G_var = theoretical HWE binomial variance 2·MAF·(1-MAF), passed in by caller.
+// G_var = empirical Var(G) over post-impute genotypes, passed in by caller.
 inline double scalarGetPvalFromScore(
     double Score,
     double altFreq,
@@ -427,7 +427,7 @@ inline double scalarGetPvalFromScore(
 // Computes the SPA p-value for a marker that failed the normal-approx
 // cutoff.  Both tails share the MAF/variance setup and outlier data
 // pointer extraction; only the Newton root and saddlepoint differ.
-// G_var = theoretical HWE binomial variance 2·MAF·(1-MAF) from caller.
+// G_var = empirical Var(G) over post-impute genotypes from caller.
 // Ratio EmpVar/Score_var is invariant to this choice, so SPA tails are stable.
 inline double fusedGetPvalSpa(
     double Score,
@@ -547,8 +547,11 @@ class SPAsqrMethod : public MethodBase {
         const double n      = static_cast<double>(GVec.size());
         const double gSum   = GVec.sum();
         const double gMean  = gSum / n;
-        const double maf    = std::min(altFreq, 1.0 - altFreq);
-        const double G_var  = 2.0 * maf * (1.0 - maf);   // theoretical HWE binomial variance
+        // Empirical Var(G) over post-impute genotypes: (Σg² − (Σg)²/n) / (n−1).
+        const double gSumSq = GVec.squaredNorm();
+        const double G_var  = (n > 1.0)
+            ? (gSumSq - gSum * gSum / n) / (n - 1.0)
+            : 0.0;
 
         Eigen::VectorXd scores = m_methodShared->residMat.transpose() * GVec;
         for (int i = 0; i < m_ntaus; ++i)
@@ -569,12 +572,16 @@ class SPAsqrMethod : public MethodBase {
         Eigen::MatrixXd scoreMatrix;
         scoreMatrix.noalias() = m_methodShared->residMat.transpose() * GBatch;
 
-        const Eigen::VectorXd gMeans = GBatch.colwise().mean();
+        const Eigen::VectorXd gMeans  = GBatch.colwise().mean();
+        const Eigen::VectorXd gSumSqs = GBatch.colwise().squaredNorm();
         scoreMatrix.noalias() -= m_methodShared->residSums * gMeans.transpose();
 
+        const double n = static_cast<double>(GBatch.rows());
         for (int b = 0; b < B; ++b) {
-            const double maf   = std::min(altFreqs[b], 1.0 - altFreqs[b]);
-            const double G_var = 2.0 * maf * (1.0 - maf);   // theoretical HWE binomial variance
+            // Empirical Var(G) over post-impute genotypes: (Σg² − n·ḡ²) / (n−1).
+            const double G_var = (n > 1.0)
+                ? (gSumSqs[b] - n * gMeans[b] * gMeans[b]) / (n - 1.0)
+                : 0.0;
             processOneMarker(scoreMatrix.col(b).data(), altFreqs[b], G_var, results[b]);
         }
     }
@@ -613,6 +620,7 @@ class SPAsqrMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
+        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
@@ -622,7 +630,8 @@ class SPAsqrMethod : public MethodBase {
 
         // ── Center scores ──────────────────────────────────────────
         m_centeredBuf = scores;
-        const double invN = 1.0 / static_cast<double>(nUsed);
+        const double nUsedD = static_cast<double>(nUsed);
+        const double invN   = 1.0 / nUsedD;
         for (int b = 0; b < B; ++b) {
             const double gMean = gSums[b] * invN;
             for (int t = 0; t < m_ntaus; ++t)
@@ -644,8 +653,12 @@ class SPAsqrMethod : public MethodBase {
                 const double Score   = m_centeredBuf(t, b);
                 const double altFreq = altFreqs[b];
                 const double MAF     = std::min(altFreq, 1.0 - altFreq);
-                // Theoretical HWE binomial variance: Var(g) = 2p(1-p).
-                const double G_var   = 2.0 * MAF * (1.0 - MAF);
+                // Empirical Var(G) over post-impute genotypes:
+                //   Var(g) = (Σg² − (Σg)²/n) / (n−1)
+                const double gSum    = gSums[b];
+                const double G_var   = (nUsedD > 1.0)
+                    ? (gSumSqs[b] - gSum * gSum / nUsedD) / (nUsedD - 1.0)
+                    : 0.0;
                 const double Svar    = G_var * tau.R_GRM_R;
 
                 double z, p;

--- a/src/spasqr/spasqr.cpp
+++ b/src/spasqr/spasqr.cpp
@@ -27,7 +27,9 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <immintrin.h>
+#if defined(__x86_64__) || defined(_M_X64)
+#  include <immintrin.h>
+#endif
 #include "util/simd_dispatch.hpp"
 #include "util/simd_math.hpp"
 
@@ -94,6 +96,8 @@ inline ScalarCgfResult scalarOutlierCgf(
 }
 
 // ── SIMD-vectorized outlier CGF (C1): processes outliers in SIMD lanes ──
+
+#if defined(__x86_64__) || defined(_M_X64)
 
 __attribute__((target("avx2,avx512f,avx512vl,fma")))
 static ScalarCgfResult simdOutlierCgf_avx512(
@@ -233,15 +237,20 @@ static ScalarCgfResult simdOutlierCgf_avx2(
     return {logMgf0Sum, tempSum, s1 - s2};
 }
 
+#endif  // x86_64 SIMD variants
+
 // ── Dispatch: pick fastest available CGF implementation ─────────────
 using OutlierCgfFn = ScalarCgfResult (*)(double, const double *, int, double);
 
 static OutlierCgfFn pickOutlierCgfFn() {
+#if defined(__x86_64__) || defined(_M_X64)
     switch (simdLevel()) {
     case SimdLevel::AVX512: return simdOutlierCgf_avx512;
     case SimdLevel::AVX2:   return simdOutlierCgf_avx2;
-    default:                return scalarOutlierCgf;
+    default: break;
     }
+#endif
+    return scalarOutlierCgf;
 }
 
 static const OutlierCgfFn outlierCgf = pickOutlierCgfFn();
@@ -370,8 +379,7 @@ struct SPAsqrSPAShared {
 };
 
 // ── Per-tau p-value (replaces SPAGRMClass::getMarkerPvalFromScore) ──
-// G_var = empirical Var(G) from the caller (post-imputation, per-pheno).
-// MAF kept for SPA CGF (binomial structural assumption); not used for variance.
+// G_var = theoretical HWE binomial variance 2·MAF·(1-MAF), passed in by caller.
 inline double scalarGetPvalFromScore(
     double Score,
     double altFreq,
@@ -419,8 +427,8 @@ inline double scalarGetPvalFromScore(
 // Computes the SPA p-value for a marker that failed the normal-approx
 // cutoff.  Both tails share the MAF/variance setup and outlier data
 // pointer extraction; only the Newton root and saddlepoint differ.
-// G_var = empirical Var(G) from caller; ratio EmpVar/Score_var is invariant
-// to the choice of variance, so SPA tails behave the same as before.
+// G_var = theoretical HWE binomial variance 2·MAF·(1-MAF) from caller.
+// Ratio EmpVar/Score_var is invariant to this choice, so SPA tails are stable.
 inline double fusedGetPvalSpa(
     double Score,
     double altFreq,
@@ -538,9 +546,9 @@ class SPAsqrMethod : public MethodBase {
 
         const double n      = static_cast<double>(GVec.size());
         const double gSum   = GVec.sum();
-        const double gSumSq = GVec.squaredNorm();
         const double gMean  = gSum / n;
-        const double G_var  = (gSumSq - gSum * gSum / n) / (n - 1.0);
+        const double maf    = std::min(altFreq, 1.0 - altFreq);
+        const double G_var  = 2.0 * maf * (1.0 - maf);   // theoretical HWE binomial variance
 
         Eigen::VectorXd scores = m_methodShared->residMat.transpose() * GVec;
         for (int i = 0; i < m_ntaus; ++i)
@@ -564,12 +572,9 @@ class SPAsqrMethod : public MethodBase {
         const Eigen::VectorXd gMeans = GBatch.colwise().mean();
         scoreMatrix.noalias() -= m_methodShared->residSums * gMeans.transpose();
 
-        const double n  = static_cast<double>(GBatch.rows());
-        const double n1 = n - 1.0;
         for (int b = 0; b < B; ++b) {
-            const double gSum   = GBatch.col(b).sum();
-            const double gSumSq = GBatch.col(b).squaredNorm();
-            const double G_var  = (gSumSq - gSum * gSum / n) / n1;
+            const double maf   = std::min(altFreqs[b], 1.0 - altFreqs[b]);
+            const double G_var = 2.0 * maf * (1.0 - maf);   // theoretical HWE binomial variance
             processOneMarker(scoreMatrix.col(b).data(), altFreqs[b], G_var, results[b]);
         }
     }
@@ -608,7 +613,6 @@ class SPAsqrMethod : public MethodBase {
     void processScoreBatch(
         const Eigen::Ref<const Eigen::MatrixXd> &scores,
         const double *gSums,
-        const double *gSumSqs,
         uint32_t nUsed,
         const std::vector<double> &altFreqs,
         std::vector<std::vector<double> > &results
@@ -618,9 +622,7 @@ class SPAsqrMethod : public MethodBase {
 
         // ── Center scores ──────────────────────────────────────────
         m_centeredBuf = scores;
-        const double n    = static_cast<double>(nUsed);
-        const double n1   = n - 1.0;
-        const double invN = 1.0 / n;
+        const double invN = 1.0 / static_cast<double>(nUsed);
         for (int b = 0; b < B; ++b) {
             const double gMean = gSums[b] * invN;
             for (int t = 0; t < m_ntaus; ++t)
@@ -642,11 +644,8 @@ class SPAsqrMethod : public MethodBase {
                 const double Score   = m_centeredBuf(t, b);
                 const double altFreq = altFreqs[b];
                 const double MAF     = std::min(altFreq, 1.0 - altFreq);
-                // Empirical Var(G) on the post-imputation, per-pheno column.
-                // gSums / gSumSqs come from the engine after Phase-1b imputation.
-                const double gSum    = gSums[b];
-                const double gSumSq  = gSumSqs[b];
-                const double G_var   = (gSumSq - gSum * gSum * invN) / n1;
+                // Theoretical HWE binomial variance: Var(g) = 2p(1-p).
+                const double G_var   = 2.0 * MAF * (1.0 - MAF);
                 const double Svar    = G_var * tau.R_GRM_R;
 
                 double z, p;

--- a/src/spasqr/spasqr.hpp
+++ b/src/spasqr/spasqr.hpp
@@ -104,5 +104,6 @@ void runSPAsqrLoco(
     double spasqrH = -1.0,
     double spasqrHScale = -1.0,
     const std::string &keepFile = {},
-    const std::string &removeFile = {}
+    const std::string &removeFile = {},
+    const std::string &locoMode = "offset"
 );

--- a/src/util/logging.hpp
+++ b/src/util/logging.hpp
@@ -10,21 +10,45 @@
 #include <ctime>
 #include <mutex>
 
+namespace logging_detail {
+inline std::mutex &mutex() {
+    static std::mutex m;
+    return m;
+}
+
+inline void writeStamped(const char *level, const char *msg) {
+    std::lock_guard<std::mutex> lk(mutex());
+    auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    char ts[20];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
+    std::fprintf(stderr, "[%s] %s %s\n", level, ts, msg);
+}
+} // namespace logging_detail
+
 // Function-local static ensures the mutex is initialized exactly once
 // even across translation units (C++17 magic statics are thread-safe).
 inline void infoMsg(
     const char *fmt,
     ...
 ) {
-    static std::mutex s_logMutex;
     char buf[512];
     va_list args;
     va_start(args, fmt);
     std::vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
-    std::lock_guard<std::mutex> lk(s_logMutex);
-    auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    char ts[20];
-    std::strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
-    std::fprintf(stderr, "[INFO] %s %s\n", ts, buf);
+    logging_detail::writeStamped("INFO", buf);
+}
+
+// Same shape as infoMsg, but tagged [WARN] for non-fatal anomalies the user
+// should notice (e.g. solver failed to converge, fell back to a default).
+inline void warnMsg(
+    const char *fmt,
+    ...
+) {
+    char buf[512];
+    va_list args;
+    va_start(args, fmt);
+    std::vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    logging_detail::writeStamped("WARN", buf);
 }

--- a/src/util/math_helper.cpp
+++ b/src/util/math_helper.cpp
@@ -286,4 +286,32 @@ OptimResult nelderMead(
     return {simplex[ilo], fvals[ilo], iter};
 }
 
+// § 5  Inverse rank normal transform (Blom, average-rank ties)
+
+Eigen::VectorXd inverseRankNormal(const Eigen::Ref<const Eigen::VectorXd> &y) {
+    const Eigen::Index N = y.size();
+    if (N == 0) throw std::runtime_error("inverseRankNormal: empty input");
+
+    std::vector<Eigen::Index> idx(static_cast<size_t>(N));
+    for (Eigen::Index i = 0; i < N; ++i) idx[static_cast<size_t>(i)] = i;
+    std::stable_sort(idx.begin(), idx.end(),
+                     [&](Eigen::Index a, Eigen::Index b) { return y[a] < y[b]; });
+
+    Eigen::VectorXd out(N);
+    const double denom = static_cast<double>(N) + 0.25;
+
+    Eigen::Index i = 0;
+    while (i < N) {
+        Eigen::Index j = i + 1;
+        while (j < N && y[idx[static_cast<size_t>(j)]] == y[idx[static_cast<size_t>(i)]]) ++j;
+        // 1-based ranks i+1 .. j ; midpoint = (i+1 + j) / 2.
+        const double avgRank = (static_cast<double>(i + 1) + static_cast<double>(j)) * 0.5;
+        const double p = (avgRank - 0.375) / denom;
+        const double z = qnorm(p);
+        for (Eigen::Index k = i; k < j; ++k) out[idx[static_cast<size_t>(k)]] = z;
+        i = j;
+    }
+    return out;
+}
+
 } // namespace math

--- a/src/util/math_helper.hpp
+++ b/src/util/math_helper.hpp
@@ -282,6 +282,12 @@ Eigen::VectorXd logisticRegression(
     const Eigen::Ref<const Eigen::VectorXd> &y
 );
 
+// Inverse rank normal transform with Blom plotting position.
+//   p_i = (rank_i - 3/8) / (N + 1/4),  Y_irn[i] = qnorm(p_i)
+// Tied values get the average of their ranks (R `ties.method="average"`).
+// Input is assumed to be NaN-free (caller filters); throws on N == 0.
+Eigen::VectorXd inverseRankNormal(const Eigen::Ref<const Eigen::VectorXd> &y);
+
 // ──────────────────────────────────────────────────────────────────────
 // § 6  Nelder-Mead simplex optimiser (n-dimensional, unconstrained)
 // ──────────────────────────────────────────────────────────────────────

--- a/src/util/simd_dispatch.hpp
+++ b/src/util/simd_dispatch.hpp
@@ -1,14 +1,18 @@
 // simd_dispatch.hpp — Runtime SIMD tier detection
 //
-// Detects AVX-512 / AVX2 / scalar at process startup via __builtin_cpu_supports().
-// Used by hot kernels (phi variance, IBD accumulation) to dispatch to the
-// widest available SIMD implementation at runtime, enabling a single binary
-// that exploits AVX-512 when present and falls back gracefully.
+// On x86_64: detects AVX-512 / AVX2 / scalar at process startup via
+// __builtin_cpu_supports().  Hot kernels dispatch to the widest available
+// SIMD implementation, enabling a single binary that exploits AVX-512 when
+// present and falls back gracefully.
+//
+// On non-x86 (e.g. arm64): always returns Scalar.  AVX kernels are not
+// compiled in; callers fall through to the scalar variant.
 #pragma once
 
 enum class SimdLevel : int { Scalar = 0, AVX2 = 1, AVX512 = 2 };
 
 inline SimdLevel simdLevel() {
+#if defined(__x86_64__) || defined(_M_X64)
     static const SimdLevel level = [] {
         __builtin_cpu_init();
         if (__builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512vl"))
@@ -18,4 +22,7 @@ inline SimdLevel simdLevel() {
         return SimdLevel::Scalar;
     }();
     return level;
+#else
+    return SimdLevel::Scalar;
+#endif
 }

--- a/src/util/simd_math.hpp
+++ b/src/util/simd_math.hpp
@@ -3,10 +3,15 @@
 // Cephes-style minimax polynomials with ~1 ULP accuracy over the full
 // double range.  No special NaN/Inf handling — SPA values are well-bounded.
 //
+// x86_64-only: on other architectures (e.g. arm64) this header expands
+// to nothing; callers must use scalar fallbacks.
+//
 // Usage:  #include "util/simd_math.hpp"
 //         __m256d y = avx2_exp_pd(x);
 //         __m512d y = avx512_exp_pd(x);
 #pragma once
+
+#if defined(__x86_64__) || defined(_M_X64)
 
 #include <immintrin.h>
 #include <cstdint>
@@ -273,3 +278,5 @@ inline __m512d avx512_log_pd(__m512d x)
 
     return _mm512_fmadd_pd(e_dbl, LN2, log_m);
 }
+
+#endif  // x86_64


### PR DESCRIPTION
1. SPAsqr score variance: empirical Var(G) replaces theoretical 2·MAF·(1−MAF)
                                                                                                                                                                                                                                                  
  The old formula assumes HWE Bernoulli, which biases on imputed dosages and markers that defy HWE. New formula:
                                                                                                                                                                                                                                                  
  G_var     = (Σg² − (Σg)²/n) / (n − 1)        // post-impute, mask-included
  Score_var = G_var · R^T Ψ R                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                  
  Same formula across all three SPAsqr paths — getResult (single marker), getResultBatch (B-marker batch), processScoreBatch (fused-GEMM). The saddlepoint adjustment uses the EmpVar/Score_var ratio.                                                                                               
                                                                                                                                                                                                                                                  
  Files:          
  - src/engine/marker_impl.hpp: add sumSq field to PhenoGenoStats; statsFromUnionVec accumulates sumSq += v*v in the mask loop (post-impute, caller has filled NaNs)
  - src/engine/marker.hpp: MethodBase::processScoreBatch signature gains const double *gSumSqs                                                                                                                                                    
  - src/engine/marker.cpp: multiPhenoEngineRange adds winGSumSqs / passGSumSqs buffers, collects gs.sumSq on QC pass, plumbs into processScoreBatch
  - src/spasqr/spasqr.cpp: single-marker uses GVec.squaredNorm(), batched uses GBatch.colwise().squaredNorm(), fused reads gSumSqs[b]; comments updated from "theoretical HWE binomial variance" → "empirical Var(G) over post-impute genotypes"  
  - src/spagrm/spagrm.hpp: SPAGRMMethod accepts the new param but (void)gSumSqs; — SPAGRM keeps its own R-GRM-R logic                                                                                                                             
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                             
  2. SPAsqr-LOCO: support LDAK-KVIK .loco format                                                                                                                                                                                                  
                                                                                                                                                                                                                                                  
  Previously only Regenie step1 .loco was accepted. LDAK-KVIK uses subject-major layout (one row per subject, columns Chr1..Chr22) — the transpose of Regenie's chr-major layout.
                                                                                                                                                                                                                                                  
  Files: src/engine/loco.cpp
  - enum class LocoFormat { Regenie, Ldak }                                                                                                                                                                                                       
  - detectLocoFormat() — sniffs the first header token: "FID_IID" → Regenie, otherwise → LDAK                                                                                                                                                     
  - parseRegenieLocoFile() (renamed from parseLocoFile) unchanged                            
  - New parseLdakLocoFile(): same mmap + strtod zero-copy parsing, but transposes row/col into chr-major aligned vectors; validates FID, IID header tokens; normalizes column names Chr1..Chr22 → "1".."22" to match downstream .bim/VCF/BGEN     
  CHROM strings                                                                                                                                                                                                                                   
  - MAP_POPULATE defined as 0 on non-Linux (macOS/BSD lack the flag)                                                                                                                                                                              
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                             
  3. SPAsqr-LOCO: new --loco-mode {offset|covariate} flag
                                                                                                                                                                                                                                                  
  Two semantics for how the LOCO PRS enters the SPAsqr null fit:
                                                                                                                                                                                                                                                  
  - offset (default): per-pheno inverse-rank-normal first, response = Y_irn − loco_chr, design = original X (no LOCO column). Treats LOCO as a fixed offset with β=1, α=0.                                                                        
  - covariate: keep raw Y, per-chr OLS fit Y_raw ~ 1 + loco_chr to get α̂, β̂, response = Y_raw − α̂ − β̂·loco_chr, design still = original X. Treats LOCO as a covariate to "partial out" before conquer.                                            
                                                                                                                                                                                                                                                  
  Both modes feed conquer the same baseX; only y_adj differs. Bandwidth h / h-scale / per-chr IQR semantics are identical across both modes.                                                                                                      
                                                                                                                                                                                                                                                  
  Files:                                                                                                                                                                                                                                          
  - src/cli/cli.hpp: Args::locoMode = "offset" default
  - src/cli/parse.cpp: else if (arg == "--loco-mode") a.locoMode = next();                                                                                                                                                                        
  - src/cli/flags.hpp: register kLocoMode flag, add to kSPAsqrOpt[]       
  - src/cli/dispatch.cpp: argsInEffect logs --loco-mode; early validation rejects values other than offset|covariate; passed to runSPAsqrLoco                                                                                                     
  - src/spasqr/spasqr.hpp: runSPAsqrLoco gains const std::string &locoMode = "offset"                                                                                                                                                             
  - src/spasqr/spasqr.cpp: runSPAsqrLoco branches on locoMode to build y_adjs[k]; offset branch calls math::inverseRankNormal(Y), covariate branch runs per-chr OLS partial-out and infoMsgs the α̂ β̂ values                                       
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                             
  4. SPAsqr: optional GRM (identity fallback when none provided)                                                                                                                                                                                  
                                                                                                                                                                                                                                                  
  Previously SPAsqr required --sp-grm-grab or --sp-grm-plink2. Now both can be omitted — falls back to identity GRM with a warnMsg flagging the unrelated-subjects assumption.
                                                                                                                                                                                                                                                  
  Files:          
  - src/cli/dispatch.cpp: checkSpGrm(args, /*required=*/false, "SPAsqr"); emits WARN when both are empty                                                                                                                                          
  - src/io/sparse_grm.cpp: SparseGRM::load() builds an N×N identity (diag = 1, no off-diag) when both grabFile and gctaFile are empty                                                                                                             
   
  ---                                                                                                                                                                                                                                             
  5. Sparse GRM .grm.id parsing + diagonal validation
                                                                                                                                                                                                                                                                                                                                                                                                            
  - .grm.id column count: GCTA standard is FID IID (2 cols), but real-world files sometimes have IID-only (1 col)                                                                                                                                 
  - buildDiagonal(): original m_diagonal.assign(m_nSubj, 0.0) silently left subjects without a diagonal entry as 0.0 → systematic underestimation of downstream R^T Ψ R                                                                           
                                                                                                                                                                                                                                                  
  Files: src/io/sparse_grm.cpp
  - readGctaIIDs(): auto-detects format from the first non-empty row by token count (1 col = IID-only / 2 cols = FID+IID), enforces consistency on subsequent rows; infoMsgs the detected format                                                  
  - buildDiagonal(): prefills with NaN instead of 0.0, scans for residual NaNs after population — any missing → throw std::runtime_error with the count of subjects missing diagonals                                                             
   
  ---                                                                                                                                                                                                                                             
  6. conquer convergence diagnostics
                                                                                                                                                                                                                                                  
  Previously a non-converged conquer fit was silent — it returned a possibly-bad β. New per-fit diagnostic struct; SPAsqr call sites now check explicitly and emit warnMsg.
                                                                                                                                                                                                                                                  
  Files:
  - src/spasqr/conquer.hpp: new ConquerStatus { converged, huberIter, huberConverged, huberFinalGradNorm, gaussIter, gaussConverged, gaussFinalGradNorm }; smqrGauss gains optional ConquerStatus *statusOut and never throws                     
  - src/spasqr/conquer.cpp: huberReg gains iterOut / finalGradNormOut out-params; smqrGauss populates ConquerStatus at the end                                                                                                                    
  - src/spasqr/spasqr.cpp: both the no-LOCO path and runSPAsqrLoco now hold a ConquerStatus st per tau; non-convergence triggers warnMsg("[%s] tau=%.4f conquer did not converge: huber=%d iters (||g||=%.3e, %s), gauss=%d iters (||g||=%.3e, 
  %s)")                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                             
  7. logging: add warnMsg                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                  
  Previously only infoMsg. The above changes need [WARN]-level messages (solver failures, fallbacks, suspicious config).
                                                                                                                                                                                                                                                  
  Files: src/util/logging.hpp
  - New warnMsg(fmt, ...) mirroring infoMsg's signature                                                                                                                                                                                           
  - Shared formatter logging_detail::writeStamped(level, msg) with a function-local static mutex (logging_detail::mutex()) used by both — replaces the TU-private s_logMutex from infoMsg                                                         
   
  ---                                                                                                                                                                                                                                             
  8. ARM portability: guard x86 SIMD intrinsics
                                                                                                                                                                                                                                                  
  Three files unconditionally #include <immintrin.h> and define helpers annotated with __attribute__((target("avx2,avx512f,..."))) using _mm256_* / _mm512_* intrinsics. On Apple Silicon: header doesn't exist, target attribute rejected by
  clang, intrinsics undefined.                                                                                                                                                                                                                    
   
  Same fix in all three: gate the <immintrin.h> include, all _avx512 / _avx2 static helper definitions, and the simdLevel() dispatch switches behind #if defined(__x86_64__) || defined(_M_X64). On non-x86 the dispatcher short-circuits to the  
  scalar baseline. Zero behavioral change on x86.
                                                                                                                                                                                                                                                  
  Files:          
  - src/spagrm/ibd.cpp: guards ibdAccPairs_avx512 / _avx2; pickIbdAccFn() returns ibdAccPairs_scalar directly on ARM
  - src/localplus/abed_io.cpp: guards decodeNoMissAVX2() (ABED 2-bit decode) / encodeSamplesAVX2() (PLINK 2-bit encode); the if (simdLevel() >= AVX2) branches inside decodeTrack and encode() are guarded too                                    
  - src/localplus/spamixlocalp.cpp: guards computeVarOffSoA_{avx512,avx2} (single marker) + computeVarOffSoABatch_{avx512,avx2} (batch); dispatchers refactored to "switch returns inside x86 guard, fall through to scalar outside"
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                             
  9. Makefile: Apple Silicon build                                                                                                                                                                                                                
                                                                                                                                                                                                                                                  
  The old Makefile didn't build on M-series:
                                                                                                                                                                                                                                                  
  - AVX2 probe with Apple clang -mavx2 doesn't fail (only warns "unused") → false positive → bogus -mavx2 on third-party libs                                                                                                                     
  - -static-libstdc++ -static-libgcc rejected by Apple clang                                                                                                                                                                                      
                                                                                                                                                                                                                                                  
  Files: Makefile 
  - Factored out IS_X86 := $(if $(filter x86_64,$(UNAME_M)),1,0)                                                                                                                                                                                  
  - AVX2 probe wrapped in ifeq ($(IS_X86),1) — non-x86 gets SIMD_FLAGS := directly                                                                                                                                                                
  - STATIC_LIBS split by platform: empty on macOS, -static-libstdc++ -static-libgcc only on Linux/MinGW
  - GRAB_MARCH: defaults to -march=native on x86 (overridable from the command line, e.g. -march=haswell); empty on non-x86                                                                                                                       
  - Comments updated: GRAB sources deliberately omit -mavx2, runtime dispatch goes through __attribute__((target))                                                                                                                                
                                                                                                                                                                                                                                                  
  ---                                                                                                                                                                                                                                             
  10. Misc                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                  
  - src/util/math_helper.{cpp,hpp}: new math::inverseRankNormal(y) — Blom plotting position (rank − 3/8)/(N + 1/4), average-rank tie handling, qnorm lookup; called by the offset LOCO path
  - src/util/simd_dispatch.hpp: comment cleanup
  - src/util/simd_math.hpp: small additions
  - .gitignore: build/, tmp/, *.R, .DS_Store, CLAUDE.md, submit_smoketest.sh

