### PR TITLE
SPAsqr: wald h-scale default 10→5, unify QMME tol at 1e-6

### DIFF
--- a/examples/baseline.sh
+++ b/examples/baseline.sh
@@ -393,7 +393,7 @@ build/grab2 \
   `# Optional flags below (set to built-in defaults):` \
   --chr 1-2,3 \
   --spasqr-taus 0.1,0.3,0.5,0.7,0.9 \
-  --spasqr-tol 1e-7 \
+  --spasqr-tol 1e-6 \
   --spasqr-h-scale 3 \
   --spasqr-mode score \
   --pheno-transform int \
@@ -436,8 +436,8 @@ build/grab2 \
   `# Optional flags below (set to built-in defaults):` \
   --chr 1-2,3 \
   --spasqr-taus 0.1,0.3,0.5,0.7,0.9 \
-  --spasqr-tol 1e-7 \
-  --spasqr-h-scale 10 \
+  --spasqr-tol 1e-6 \
+  --spasqr-h-scale 5 \
   --spasqr-mode wald \
   --pheno-transform int \
   --outlier-iqr-multiplier 1.5 \

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -24,9 +24,9 @@ struct Args {
     std::string spasqrTaus = "0.1,0.3,0.5,0.7,0.9"; // default tau levels (SPAsqr)
     std::string sageldX;                            // --sageld-x: comma-separated env names for SAGELD pheno mode
     std::string sageldMethod = "sageld";            // --sageld-method: 'sageld' (score, default) or 'gallop' (Wald)
-    double spasqrTol = 1e-7;                          // --spasqr-tol (QMME convergence tolerance)
+    double spasqrTol = 1e-6;                          // --spasqr-tol (QMME convergence tolerance)
     double spasqrH = -1.0;                            // --spasqr-h (explicit bandwidth; -1 = auto)
-    double spasqrHScale = -1.0;                       // --spasqr-h-scale (IQR divisor; -1 = auto: score=3, wald=10)
+    double spasqrHScale = -1.0;                       // --spasqr-h-scale (IQR divisor; -1 = auto: score=3, wald=5)
     std::string bfilePrefix;
     std::string pfilePrefix; // --pfile (pgen/pvar/psam)
     std::string vcfFile;     // --vcf (VCF text, or BGZF-compressed .vcf.gz)

--- a/src/cli/dispatch.cpp
+++ b/src/cli/dispatch.cpp
@@ -264,7 +264,7 @@ static void logArgsInEffect(const Args &args) {
         std::fprintf(stderr, "  --spasqr-mode %s\n", args.spasqrMode.c_str());
         if (!args.spasqrTaus.empty())
             std::fprintf(stderr, "  --spasqr-taus %s\n", args.spasqrTaus.c_str());
-        if (args.spasqrTol != 1e-7)
+        if (args.spasqrTol != 1e-6)
             std::fprintf(stderr, "  --spasqr-tol %g\n", args.spasqrTol);
         if (args.spasqrH >= 0.0)
             std::fprintf(stderr, "  --spasqr-h %g\n", args.spasqrH);

--- a/src/cli/flags.hpp
+++ b/src/cli/flags.hpp
@@ -579,8 +579,9 @@ develop-R SAGELD.NullModel UsedMethod argument).  Only meaningful with
 
 inline const FlagDef kSpasqrTol = {
     "--spasqr-tol", "FLOAT",
-    "Convergence tolerance for the SPAsqr null-model SQR solver (default: 1e-7). "
-    "QMME tightens this internally to min(--spasqr-tol, 1e-9).",
+    "Convergence tolerance for the SPAsqr null-model SQR solver (default: 1e-6). "
+    "Applied directly as the QMME ||grad||_inf convergence threshold in both "
+    "score and wald modes.",
     nullptr
 };
 

--- a/src/spasqr/qmme.hpp
+++ b/src/spasqr/qmme.hpp
@@ -46,7 +46,7 @@ class SqrSolver {
         const Eigen::VectorXd &Y,
         double tau,
         Eigen::VectorXd *residOut = nullptr,
-        double tol = 1e-7,
+        double tol = 1e-6,
         int maxIter = 5000,
         int restartPeriod = 50,
         SolverStatus *statusOut = nullptr,

--- a/src/spasqr/spasqr.cpp
+++ b/src/spasqr/spasqr.cpp
@@ -1057,9 +1057,9 @@ void runSPAsqr(
     infoMsg("SPAsqr: pheno-transform = %s, solver = qmme",
             phenoTransform.c_str());
     infoMsg("SPAsqr: Loading phenotype and covariate data (%d phenotypes, %d taus)", K, ntaus);
-    // QMME is more accurate per-iteration; tighten its convergence floor
-    // by an extra factor without changing the user's --spasqr-tol meaning.
-    const double qmmeTol = std::min(spasqrTol, 1e-9);
+    // Score mode fits the null model once and reuses it for every marker, so
+    // --spasqr-tol (default 1e-6) is tight enough; apply it directly.
+    const double qmmeTol = spasqrTol;
     auto famIIDs = parseGenoIIDs(geno);
     SubjectData sd(std::move(famIIDs));
     if (!phenoFile.empty()) sd.loadPhenoFile(phenoFile, phenoNames);
@@ -1359,7 +1359,7 @@ void runSPAsqrLoco(
     infoMsg("SPAsqr-LOCO pheno-transform: %s, solver: qmme",
             phenoTransform.c_str());
     infoMsg("SPAsqr-LOCO: Loading phenotype and covariate data (%d phenotypes, %d taus)", K, ntaus);
-    const double qmmeTol = std::min(spasqrTol, 1e-9);
+    const double qmmeTol = spasqrTol;
     auto famIIDs = parseGenoIIDs(geno);
     SubjectData sd(std::move(famIIDs));
     if (!phenoFile.empty()) sd.loadPhenoFile(phenoFile, phenoNames);

--- a/src/spasqr/spasqr.hpp
+++ b/src/spasqr/spasqr.hpp
@@ -69,7 +69,7 @@ void runSPAsqr(
     double minMafCutoff,
     double minMacCutoff,
     double hweCutoff,
-    double spasqrTol = 1e-7,
+    double spasqrTol = 1e-6,
     double spasqrH = -1.0,
     double spasqrHScale = -1.0,
     const std::string &keepFile = {},
@@ -96,7 +96,7 @@ void runSPAsqrWald(
     const std::string &outPrefix,
     double spasqrTol,
     double spasqrH,                         // -1 → IQR-based auto
-    double spasqrHScale,                    // -1 → 10
+    double spasqrHScale,                    // -1 → 5
     double missingCutoff,
     double minMafCutoff,
     double minMacCutoff,
@@ -134,7 +134,7 @@ void runSPAsqrLoco(
     double minMafCutoff,
     double minMacCutoff,
     double hweCutoff,
-    double spasqrTol = 1e-7,
+    double spasqrTol = 1e-6,
     double spasqrH = -1.0,
     double spasqrHScale = -1.0,
     const std::string &keepFile = {},

--- a/src/spasqr/spasqr_wald.cpp
+++ b/src/spasqr/spasqr_wald.cpp
@@ -196,7 +196,7 @@ class SPAsqrWaldMethod : public MethodBase {
         std::vector<double> taus;
         std::vector<std::string> tauLabels;
         double h        = 0.0;
-        double qmmeTol  = 1e-7;
+        double qmmeTol  = 1e-6;
         int    maxIter  = 5000;
     };
 
@@ -329,14 +329,14 @@ void runSPAsqrWald(
     const int K = static_cast<int>(phenoNames.size());
     const int ntaus = static_cast<int>(taus.size());
     const bool useLoco = !predListFile.empty();
-    // Wald defaults to h-scale=10 (vs score-mode's 3): per-marker QMME refits
+    // Wald defaults to h-scale=5 (vs score-mode's 3): per-marker QMME refits
     // with G in the design benefit from a smaller bandwidth so the kernel
     // weight K_h(-e) better resolves the score density f(0) and the
     // sandwich-derived SE matches the Gaussian asymptotic limit.
-    const double effHScale = (spasqrHScale >= 0.0) ? spasqrHScale : 10.0;
+    const double effHScale = (spasqrHScale >= 0.0) ? spasqrHScale : 5.0;
     // Wald refits per (marker, τ) — keep iter cap modest. The ε_grad tolerance
-    // tracks the user's --spasqr-tol directly (not floored to 1e-9 like score
-    // mode, which fits once and reuses) so a single bad fit can't hang the run.
+    // tracks the user's --spasqr-tol directly so a single bad fit can't hang the
+    // run; score mode applies the same tolerance to its one-time null fit.
     const double qmmeTol = spasqrTol;
     const int maxIter = 5000;
 


### PR DESCRIPTION
- Wald-mode default --spasqr-h-scale changed 10 → 5.
- --spasqr-tol default changed 1e-7 → 1e-6 across the CLI default, the QMME solver signature, the wald Shared struct, and the public SPAsqr function signatures.
- Score mode now applies --spasqr-tol directly instead of flooring to min(tol, 1e-9); score and wald modes are unified on one tolerance.
- Update --spasqr-tol flag help, the dispatch non-default echo guard, and the examples/baseline.sh documentary default lines.